### PR TITLE
Add service file for CopyrightRangeProvider

### DIFF
--- a/license-maven-plugin-git/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
+++ b/license-maven-plugin-git/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
@@ -1,0 +1,1 @@
+com.mycila.maven.plugin.license.git.CopyrightRangeProvider


### PR DESCRIPTION
Trying to use the license-maven-plugin-git for the first time, I found out that the service file is missing :(