### PR TITLE
Changed the double tab to one tab

### DIFF
--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/APACHE-2.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/APACHE-2.txt
@@ -4,7 +4,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
The current Apache License, Version 2.0 has two tabs (8 spaces). But the officiel Apache License, Version 2.0 has one tab (4 spaces); http://www.apache.org/licenses/LICENSE-2.0.html#apply