### PR TITLE
Issue #41 - Fix license templates

### DIFF
--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/AGPL-3.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/AGPL-3.txt
@@ -1,14 +1,15 @@
-This file is part of ${project.name}.
+${project.name} - ${project.description}
+Copyright © ${project.inceptionYear} ${owner} (${email})
 
-${project.name} is free software: you can redistribute it and/or modify
+This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Affero General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-${project.name} is distributed in the hope that it will be useful,
+This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU Affero General Public License for more details.
 
 You should have received a copy of the GNU Affero General Public License
-along with ${project.name}.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/APACHE-2.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/APACHE-2.txt
@@ -1,4 +1,4 @@
-Copyright (C) ${project.inceptionYear} ${owner} (${email})
+Copyright © ${project.inceptionYear} ${owner} (${email})
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/CPAL.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/CPAL.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${owner}.  All rights reserved.  ${project.url}
+Copyright © ${owner}.  All rights reserved.  ${project.url}
 The software in this package is published under the terms of the CPAL v1.0
 license, a copy of which has been included with this distribution in the
 LICENSE.txt file.

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/GPL-3.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/GPL-3.txt
@@ -1,14 +1,15 @@
-This file is part of ${project.name}.
+${project.name} - ${project.description}
+Copyright © ${project.inceptionYear} ${owner} (${email})
 
-${project.name} is free software: you can redistribute it and/or modify
+This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-${project.name} is distributed in the hope that it will be useful,
+This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with ${project.name}.  If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/LGPL-3.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/LGPL-3.txt
@@ -1,14 +1,15 @@
-This file is part of ${project.name}.
+${project.name} - ${project.description}
+Copyright © ${project.inceptionYear} ${owner} (${email})
 
-${project.name} is free software: you can redistribute it and/or modify
+This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU Lesser General Public License as published by
 the Free Software Foundation, either version 3 of the License, or
 (at your option) any later version.
 
-${project.name} is distributed in the hope that it will be useful,
+This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU Lesser General Public License for more details.
 
 You should have received a copy of the GNU Lesser General Public License
-along with ${project.name}.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MIT.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MIT.txt
@@ -1,5 +1,5 @@
 The MIT License
-Copyright (c) ${project.inceptionYear} ${owner}
+Copyright © ${project.inceptionYear} ${owner}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MPL-2.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MPL-2.txt
@@ -1,4 +1,4 @@
-Copyright (c) ${project.inceptionYear}, ${owner} <${email}>
+Copyright © ${project.inceptionYear}, ${owner} <${email}>
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
- (c) and (C) were both converted to ©
- '${project.name}' was replaced w/ 'This program'
- GPL licences got their proper introduction

See https://www.gnu.org/licenses/gpl-3.0.html and https://www.gnu.org/licenses/gpl-howto.html for information about how to use GPL licences.
