### PR TITLE
Add The MirOS Licence

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Maven license plugin comes with the following license templates:
  - APACHE 2
  - BSD 2, 3, 4
  - LGPL 3
+ - MirOS
  - MIT
  - MPL 2
  - WTFPL

--- a/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MirOS.txt
+++ b/license-maven-plugin/src/main/resources/com/mycila/maven/plugin/license/templates/MirOS.txt
@@ -1,0 +1,17 @@
+Copyright © ${project.inceptionYear}
+	${owner} <${email}>
+
+Provided that these terms and disclaimer and all copyright notices
+are retained or reproduced in an accompanying document, permission
+is granted to deal in this work without restriction, including un‐
+limited rights to use, publicly perform, distribute, sell, modify,
+merge, give away, or sublicence.
+
+This work is provided “AS IS” and WITHOUT WARRANTY of any kind, to
+the utmost extent permitted by applicable law, neither express nor
+implied; without malicious intent or gross negligence. In no event
+may a licensor, author or contributor be held liable for indirect,
+direct, other damage, loss, or other issues arising in any way out
+of dealing in the work, even if advised of the possibility of such
+damage or existence of a defect, except proven that it results out
+of said person’s immediate fault when using the work as intended.


### PR DESCRIPTION
This is actually a Free Software licence and OSI certified.

This is part 1; part 2 would be to actually list all relevant copyright years,
and not a range (dash-delimited — actually ‘–’-delimited (en dash),
not ‘-’-delimited (hyphen-minus)) either, but that’s still open:
https://github.com/mycila/license-maven-plugin/issues/95