### PR TITLE
add JAVAPKG_STYLE to supplant JAVADOC_STYLE, don’t bind by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,14 @@ The plugin enables you to add any other mapping you want.* I.e., if you are deve
 
 You can use composed-extensions like *.apt.vm and redefine them, but you will have to nake sure that the mapping of `apt.vm` is _before_ the mapping of the `vm` extension. The order in the mapping section is important: extensions seen first take precedence.
 
+__Java packages__
+
+Another use case for custom mappings is when writing Java code in packages; the licence header should come *after* the package declaration line in this case. Simply add this to the plugin configuration:
+
+    <mapping>
+        <java>JAVAPKG_STYLE</java>
+    </mapping>
+
 ### Changing header style definitions ###
 
 In license-maven-plugin, each header style is defined by patterns to detect it and also strings to insert it correctly in files. If we take for example the Javadoc style header definition. It is defined as follow:

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The plugin has been designed so that it is very easy to add new supports for new
      */
 ```
 
- - `JAVAPKG_STYLE` (like Javadoc, but only for files that are in a Java package, skips the first line): not assigned to a file extension by default
+ - `JAVAPKG_STYLE` (like Javadoc, but only for files that are in a Java package, skips the first line): not assigned to a file extension by default (see __Java packages__ below for how to enable it)
 
 ```
     package com.example;

--- a/README.md
+++ b/README.md
@@ -185,6 +185,15 @@ The plugin has been designed so that it is very easy to add new supports for new
      */
 ```
 
+ - `JAVAPKG_STYLE` (like Javadoc, but only for files that are in a Java package, skips the first line): not assigned to a file extension by default
+
+```
+    package com.example;
+    /*-
+     * My comment
+     */
+```
+
  - `XML_STYLE` (XML-like comments): *.pom, *.xml, *.xhtml, *.mxml, *.dtd, *.xsd, *.jspx, *.fml, *.xsl, *.html, *.htm, *.kml, *.gsp, *.tld
 
 ```

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderType.java
@@ -32,6 +32,7 @@ public enum HeaderType {
     //              firstLine   beforeEachLine   endLine   afterEachLine   skipLinePattern   firstLineDetectionPattern   endLineDetectionPattern   allowBlankLines   isMultiline   padLines
     //generic
     JAVADOC_STYLE("/**", " * ", " */", "", null, "(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
+    JAVAPKG_STYLE("EOL/*-", " * ", " */", "", "^package [a-z]+(\\.[a-z][a-z0-9]*)*;$", "(EOL)*(\\s|\\t)*/\\*.*$", ".*\\*/(\\s|\\t)*$", false, true, false),
     SCRIPT_STYLE("#", "# ", "#EOL", "", "^#!.*$", "#.*$", "#.*$", false, false, false),
     HAML_STYLE("-#", "-# ", "-#EOL", "", "^-#!.*$", "-#.*$", "-#.*$", false, false, false),
     XML_STYLE("<!--EOL", "    ", "EOL-->", "", "^<\\?xml.*>$", "(\\s|\\t)*<!--.*$", ".*-->(\\s|\\t)*$", true, true, false),

--- a/license-maven-plugin/src/test/resources/styles/javapkg_style.txt
+++ b/license-maven-plugin/src/test/resources/styles/javapkg_style.txt
@@ -1,0 +1,15 @@
+/*-
+ * Copyright (C) ${year} http://code.google.com/p/maven-license-plugin/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/license-maven-plugin/src/test/resources/styles/javapkg_style.txt
+++ b/license-maven-plugin/src/test/resources/styles/javapkg_style.txt
@@ -1,3 +1,4 @@
+
 /*-
  * Copyright (C) ${year} http://code.google.com/p/maven-license-plugin/
  *


### PR DESCRIPTION
Closes: https://github.com/mycila/license-maven-plugin/issues/38
