### PR TITLE
When a multi-line inlineHeader is provided, remove indenting

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
@@ -91,7 +91,7 @@ public abstract class HeaderSource {
      */
     public static HeaderSource of(String inlineHeader, String headerPath, String encoding, ResourceFinder finder) {
         if (inlineHeader != null && !inlineHeader.isEmpty()) {
-            return new LiteralHeaderSource(inlineHeader);
+            return new LiteralHeaderSource(reformatInlineHeader(inlineHeader));
         } else if (headerPath == null) {
             throw new IllegalArgumentException("Either inlineHeader or header path need to be specified");
         } else {
@@ -103,6 +103,34 @@ public abstract class HeaderSource {
                         "Cannot read header document " + headerPath + ". Cause: " + e.getMessage(), e);
             }
         }
+    }
+
+  /**
+   * Remove indent from multi-line inline headers
+   */
+    private static String reformatInlineHeader(String inlineHeader) {
+      
+        // Do not reformat single-line headers
+        if(!inlineHeader.contains("\n")) {
+          return inlineHeader;
+        }
+      
+        // Choose CRLF or LF based on the input text
+        String newline;
+        if(inlineHeader.contains("\r")) {
+          newline = "\r\n";
+        } else {
+          newline = "\n";
+        }
+      
+        StringBuilder reformatted = new StringBuilder();
+        String[] lines = inlineHeader.split("\\r?\\n");
+
+        for (String line : lines) {
+            reformatted.append(line.trim()).append(newline);
+        }
+        
+        return reformatted.toString();
     }
 
     protected final String content;


### PR DESCRIPTION
Ideally, you should be able to include an `inlineHeader` like so:
```.xml
 <plugin>
        <groupId>com.mycila</groupId>
        <artifactId>license-maven-plugin</artifactId>
        <version>3.1-SNAPSHOT</version>
        <configuration>
          <inlineHeader>
              Renjin : JVM-based interpreter for the R language for the statistical analysis
              ${project.name}
              Copyright © ${project.inceptionYear} BeDataDriven Groep B.V. and contributors
              
              This program is free software; you can redistribute it and/or modify
              it under the terms of the GNU General Public License as published by
              the Free Software Foundation; either version 2 of the License, or
              (at your option) any later version.
              
              This program is distributed in the hope that it will be useful,
              but WITHOUT ANY WARRANTY; without even the implied warranty of
              MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
              GNU General Public License for more details.
              
              You should have received a copy of the GNU General Public License
              along with this program; if not, a copy is available at
              https://www.gnu.org/licenses/gpl-2.0.txt
          </inlineHeader>
          <mapping>
            <R>SCRIPT_STYLE</R>
          </mapping>
          <includes>
            <include>**/*.java</include>
            <include>**/*.R</include>
          </includes>
        </configuration>
      </plugin>
```
However, in this case the ident from the XML file is replicated across the source files. This PR trims each line if multiple lines are provided.