### PR TITLE
Update error message property name

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {
 
-    @Parameter(property = "license.error.message", defaultValue = "Some files do not have the expected license header")
+    @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header")
     public String errorMessage = "Some files do not have the expected license header";
 
     public final Collection<File> missingHeaders = new ConcurrentLinkedQueue<File>();


### PR DESCRIPTION
Updated error message property name in LicenseCheckMojo, previous value was not displayed correctly in documentation leading to incorrect configuration of user project.