### PR TITLE
Track the year of a file creation through license-maven-plugin-git

### DIFF
--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightRangeProvider.java
@@ -39,6 +39,7 @@ import com.mycila.maven.plugin.license.git.GitLookup.DateSource;
 public class CopyrightRangeProvider implements PropertiesProvider {
 
     public static final String COPYRIGHT_LAST_YEAR_KEY = "license.git.copyrightLastYear";
+    public static final String COPYRIGHT_CREATION_YEAR_KEY = "license.git.copyrightCreationYear";
     public static final String COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY = "license.git.copyrightLastYearMaxCommitsLookup";
     public static final String COPYRIGHT_LAST_YEAR_SOURCE_KEY = "license.git.copyrightLastYearSource";
     public static final String COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY = "license.git.copyrightLastYearTimeZone";
@@ -52,14 +53,17 @@ public class CopyrightRangeProvider implements PropertiesProvider {
     }
 
     /**
-     * Returns an unmodifiable map containing two entries {@value #COPYRIGHT_LAST_YEAR_KEY} and
-     * {@value #COPYRIGHT_YEARS_KEY} whose values are set based on inspecting git history.
+     * Returns an unmodifiable map containing the three entries {@value #COPYRIGHT_LAST_YEAR_KEY}, {@value #COPYRIGHT_YEARS_KEY},
+     * and {@value #COPYRIGHT_CREATION_YEAR_KEY}, whose values are set based on inspecting git history.
+     *
      * <ul>
-     * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the commiter date of the last git commit that has
+     * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
      * modified the supplied {@code document}.
      * <li>{@value #COPYRIGHT_YEARS_KEY} key stores the range from {@value #INCEPTION_YEAR_KEY} value to
      * {@value #COPYRIGHT_LAST_YEAR_KEY} value. If both values a equal, only the {@value #INCEPTION_YEAR_KEY} value is
      * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000 - 2010"}.
+     * <li>{@value #COPYRIGHT_CREATION_YEAR_KEY} key stores the year from the committer date of the first git commit for
+     * the supplied {@code document}.
      * </ul>
      * The {@value #INCEPTION_YEAR_KEY} value is read from the supplied properties and it must available. Otherwise a
      * {@link RuntimeException} is thrown.
@@ -81,7 +85,8 @@ public class CopyrightRangeProvider implements PropertiesProvider {
         }
         try {
             Map<String, String> result = new HashMap<String, String>(3);
-            int copyrightEnd = getGitLookup(document.getFile(), properties).getYearOfLastChange(document.getFile());
+            GitLookup gitLookup = getGitLookup(document.getFile(), properties);
+            int copyrightEnd = gitLookup.getYearOfLastChange(document.getFile());
             result.put(COPYRIGHT_LAST_YEAR_KEY, Integer.toString(copyrightEnd));
             final String copyrightYears;
             if (inceptionYearInt >= copyrightEnd) {
@@ -90,6 +95,9 @@ public class CopyrightRangeProvider implements PropertiesProvider {
                 copyrightYears = inceptionYear + "-" + copyrightEnd;
             }
             result.put(COPYRIGHT_YEARS_KEY, copyrightYears);
+
+            int copyrightStart = gitLookup.getYearOfCreation(document.getFile());
+            result.put(COPYRIGHT_CREATION_YEAR_KEY, Integer.toString(copyrightStart));
             return Collections.unmodifiableMap(result);
         } catch (Exception e) {
             throw new RuntimeException("Could not compute the year of the last git commit for file "

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -17,18 +17,23 @@ package com.mycila.maven.plugin.license.git;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.TimeZone;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
+import org.eclipse.jgit.diff.DiffConfig;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.FollowFilter;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.filter.MaxCountRevFilter;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
@@ -64,7 +69,7 @@ public class GitLookup {
      *            - any path from the working tree of the git repository to consider in all subsequent calls to
      *            {@link #getYearOfLastChange(File)}
      * @param dateSource
-     *            where to read the comit dates from - committer date or author date
+     *            where to read the commit dates from - committer date or author date
      * @param timeZone
      *            the time zone if {@code dateSource} is {@link DateSource#COMMITER}; otherwise must be {@code null}.
      * @param checkCommitsCount
@@ -102,43 +107,23 @@ public class GitLookup {
      * <p>
      * See also the note on time zones in {@link #GitLookup(File, DateSource, TimeZone, int)}.
      *
-     * @param file
-     * @return
-     * @throws NoHeadException
-     * @throws GitAPIException
-     * @throws IOException
+     * @param file for which the year should be retrieved
+     * @return year of last modification of the file
+     * @throws NoHeadException if unable to retrieve the head of the git history
+     * @throws IOException if unable to read the file
+     * @throws GitAPIException if unable to process the git history
      */
-    public int getYearOfLastChange(File file) throws NoHeadException, GitAPIException, IOException {
+    int getYearOfLastChange(File file) throws NoHeadException, GitAPIException, IOException {
         String repoRelativePath = pathResolver.relativize(file);
 
-        Status status = new Git(repository).status().addPath(repoRelativePath).call();
-        if (!status.isClean()) {
-            /* Return the current year for modified and unstaged files */
-            return toYear(System.currentTimeMillis(), timeZone != null ? timeZone : DEFAULT_ZONE);
+        if (isFileModifiedOrUnstaged(repoRelativePath)) {
+            return getCurrentYear();
         }
 
-        RevWalk walk = new RevWalk(repository);
-        walk.markStart(walk.parseCommit(repository.resolve(Constants.HEAD)));
-        walk.setTreeFilter(AndTreeFilter.create(PathFilter.create(repoRelativePath), TreeFilter.ANY_DIFF));
-        walk.setRevFilter(MaxCountRevFilter.create(checkCommitsCount));
-        walk.setRetainBody(false);
-
         int commitYear = 0;
+        RevWalk walk = getGitRevWalk(repoRelativePath, false);
         for (RevCommit commit : walk) {
-            int y;
-            switch (dateSource) {
-            case COMMITER:
-                int epochSeconds = commit.getCommitTime();
-                y = toYear(epochSeconds * 1000L, timeZone);
-                break;
-            case AUTHOR:
-                PersonIdent id = commit.getAuthorIdent();
-                Date date = id.getWhen();
-                y = toYear(date.getTime(), id.getTimeZone());
-                break;
-            default:
-                throw new IllegalStateException("Unexpected " + DateSource.class.getName() + " " + dateSource);
-            }
+            int y = getYearFromCommit(commit);
             if (y > commitYear) {
                 commitYear = y;
             }
@@ -147,6 +132,75 @@ public class GitLookup {
         return commitYear;
     }
 
+    /**
+     * Returns the year of creation for the given {@code file) based on the history of the present git branch. The
+     * year is taken either from the committer date or from the author identity depending on how {@link #dateSource} was
+     * initialized.
+     *
+     * @param file for which the year should be retrieved
+     * @return year of creation of the file
+     * @throws IOException if unable to read the file
+     * @throws GitAPIException if unable to process the git history
+     */
+    int getYearOfCreation(File file) throws IOException, GitAPIException {
+        String repoRelativePath = pathResolver.relativize(file);
+
+        if (isFileModifiedOrUnstaged(repoRelativePath)) {
+            return getCurrentYear();
+        }
+
+        int commitYear = 0;
+        RevWalk walk = getGitRevWalk(repoRelativePath, true);
+        Iterator<RevCommit> iterator = walk.iterator();
+        if (iterator.hasNext()) {
+            RevCommit commit = iterator.next();
+            commitYear = getYearFromCommit(commit);
+        }
+        walk.dispose();
+        return commitYear;
+    }
+
+    private boolean isFileModifiedOrUnstaged(String repoRelativePath) throws GitAPIException {
+        Status status = new Git(repository).status().addPath(repoRelativePath).call();
+        return !status.isClean();
+    }
+
+    private RevWalk getGitRevWalk(String repoRelativePath, boolean oldestCommitsFirst) throws IOException {
+        DiffConfig diffConfig = repository.getConfig().get(DiffConfig.KEY);
+
+        RevWalk walk = new RevWalk(repository);
+        walk.markStart(walk.parseCommit(repository.resolve(Constants.HEAD)));
+        walk.setTreeFilter(AndTreeFilter.create(Arrays.asList(
+                PathFilter.create(repoRelativePath),
+                FollowFilter.create(repoRelativePath, diffConfig), // Allows us to follow files as they move or are renamed
+                TreeFilter.ANY_DIFF)
+        ));
+        walk.setRevFilter(MaxCountRevFilter.create(checkCommitsCount));
+        walk.setRetainBody(false);
+        if (oldestCommitsFirst) {
+            walk.sort(RevSort.REVERSE);
+        }
+
+        return walk;
+    }
+
+    private int getCurrentYear() {
+        return toYear(System.currentTimeMillis(), timeZone != null ? timeZone : DEFAULT_ZONE);
+    }
+
+    private int getYearFromCommit(RevCommit commit) {
+        switch (dateSource) {
+            case COMMITER:
+                int epochSeconds = commit.getCommitTime();
+                return toYear(epochSeconds * 1000L, timeZone);
+            case AUTHOR:
+                PersonIdent id = commit.getAuthorIdent();
+                Date date = id.getWhen();
+                return toYear(date.getTime(), id.getTimeZone());
+            default:
+                throw new IllegalStateException("Unexpected " + DateSource.class.getName() + " " + dateSource);
+        }
+    }
     private static int toYear(long epochMilliseconds, TimeZone timeZone) {
         Calendar result = Calendar.getInstance(timeZone);
         result.setTimeInMillis(epochMilliseconds);

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightRangeProviderTest.java
@@ -16,7 +16,6 @@
 package com.mycila.maven.plugin.license.git;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
@@ -30,7 +29,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.mycila.maven.plugin.license.document.Document;
-import com.mycila.maven.plugin.license.git.CopyrightRangeProvider;
 
 /**
  * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
@@ -44,25 +42,25 @@ public class CopyrightRangeProviderTest {
     public void copyrightRange() {
         CopyrightRangeProvider provider = new CopyrightRangeProvider();
 
-        assertRange(provider, "dir1/file1.txt", "2006", "1999-2006");
-        assertRange(provider, "dir2/file2.txt", "2007", "1999-2007");
-        assertRange(provider, "dir1/file3.txt", "2009", "1999-2009");
-        assertRange(provider, "dir2/file4.txt", "1999", "1999");
+        assertRange(provider, "dir1/file1.txt", "2000", "2006", "1999-2006");
+        assertRange(provider, "dir2/file2.txt", "2007", "2007", "1999-2007");
+        assertRange(provider, "dir1/file3.txt", "2009", "2009", "1999-2009");
+        assertRange(provider, "dir2/file4.txt", "1999", "1999", "1999");
 
         /* The last change of file4.txt in git history is in 1999
          * but the inception year is 2000
          * and we do not want the range to go back (2000-1999)
          * so in this case we expect just 2000 */
-        assertRange(provider, "dir2/file4.txt", "2000", "1999", "2000");
+        assertRange(provider, "dir2/file4.txt", "2000", "1999", "1999", "2000");
 
     }
 
-    private static void assertRange(CopyrightRangeProvider provider, String path, String copyrightEnd, String copyrightRange) {
-        assertRange(provider, path, "1999", copyrightEnd, copyrightRange);
+    private void assertRange(CopyrightRangeProvider provider, String path, String copyrightStart, String copyrightEnd, String copyrightRange) {
+        assertRange(provider, path, "1999", copyrightStart, copyrightEnd, copyrightRange);
     }
 
-    private static void assertRange(CopyrightRangeProvider provider, String path, String inceptionYear,
-            String copyrightEnd, String copyrightRange) {
+    private void assertRange(CopyrightRangeProvider provider, String path, String inceptionYear,
+            String copyrightStart, String copyrightEnd, String copyrightRange) {
         Properties props = new Properties();
         props.put(CopyrightRangeProvider.INCEPTION_YEAR_KEY, inceptionYear);
 
@@ -70,6 +68,7 @@ public class CopyrightRangeProviderTest {
         Map<String, String> actual = provider.getAdditionalProperties(null, props, document);
 
         HashMap<String, String> expected = new HashMap<String, String>();
+        expected.put(CopyrightRangeProvider.COPYRIGHT_CREATION_YEAR_KEY, copyrightStart);
         expected.put(CopyrightRangeProvider.COPYRIGHT_LAST_YEAR_KEY, copyrightEnd);
         expected.put(CopyrightRangeProvider.COPYRIGHT_YEARS_KEY, copyrightRange);
         Assert.assertEquals("for file '" + path + "': ", expected, actual);
@@ -83,7 +82,7 @@ public class CopyrightRangeProviderTest {
     }
 
     @BeforeClass
-    public static void beforeClass() throws FileNotFoundException, IOException {
+    public static void beforeClass() throws IOException {
         tempFolder = new TemporaryFolder();
         tempFolder.create();
 


### PR DESCRIPTION
Reason behind this PR:
Sometimes you are required to include in your license header only the
date of the file creation.
These changes allow us to look at the git history and find the year of
reation for a given file.

Note:
Sometimes git is unable to figure out the date of creation of a file if
this has moved/renamed without git being able to detect such change.
A potential future solution could be to avoid dates to be overwritten.
I would leave that for another PR though.

Additionally, this PR reduces a bit of duplicated code in the git plugin.