### PR TITLE
added provider of author name and email address obtained from first commit

### DIFF
--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
@@ -25,27 +25,25 @@ import com.mycila.maven.plugin.license.PropertiesProvider;
 import com.mycila.maven.plugin.license.document.Document;
 
 /**
- * An implementation of {@link PropertiesProvider} that adds {@value #COPYRIGHT_LAST_YEAR_KEY} and
- * {@value #COPYRIGHT_YEARS_KEY} values - see
+ * An implementation of {@link PropertiesProvider} that adds {@value #COPYRIGHT_CREATION_AUTHOR_NAME_KEY} and
+ * {@value #COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY} values - see
  * {@link #getAdditionalProperties(AbstractLicenseMojo, Properties, Document)}.
  *
- * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
+ * @author masakimu
  */
-public class CopyrightRangeProvider extends GitPropertiesProvider implements PropertiesProvider {
+public class CopyrightAuthorProvider extends GitPropertiesProvider implements PropertiesProvider {
 
-    public static final String COPYRIGHT_LAST_YEAR_KEY = "license.git.copyrightLastYear";
-    public static final String COPYRIGHT_CREATION_YEAR_KEY = "license.git.copyrightCreationYear";
-    public static final String COPYRIGHT_YEARS_KEY = "license.git.copyrightYears";
-    public static final String INCEPTION_YEAR_KEY = "project.inceptionYear";
+    public static final String COPYRIGHT_CREATION_AUTHOR_NAME_KEY= "license.git.CreationAuthorName";
+    public static final String COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY="license.git.CreationAuthorEmail";
     
 
-    public CopyrightRangeProvider() {
+    public CopyrightAuthorProvider() {
         super();
     }
 
     /**
-     * Returns an unmodifiable map containing the three entries {@value #COPYRIGHT_LAST_YEAR_KEY}, {@value #COPYRIGHT_YEARS_KEY},
-     * and {@value #COPYRIGHT_CREATION_YEAR_KEY}, whose values are set based on inspecting git history.
+     * Returns an unmodifiable map containing the two entries {@value #COPYRIGHT_CREATION_AUTHOR_NAME_KEY} and {@value #COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY},
+     * , whose values are set based on inspecting git history.
      *
      * <ul>
      * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
@@ -62,37 +60,20 @@ public class CopyrightRangeProvider extends GitPropertiesProvider implements Pro
      */
     public Map<String, String> getAdditionalProperties(AbstractLicenseMojo mojo, Properties properties,
             Document document) {
-        String inceptionYear = properties.getProperty(INCEPTION_YEAR_KEY);
-        if (inceptionYear == null) {
-            throw new RuntimeException("'"+ INCEPTION_YEAR_KEY +"' must have a value for file "
-                    + document.getFile().getAbsolutePath());
-        }
-        final int inceptionYearInt;
-        try {
-            inceptionYearInt = Integer.parseInt(inceptionYear);
-        } catch (NumberFormatException e1) {
-            throw new RuntimeException("'"+ INCEPTION_YEAR_KEY +"' must be an integer ; found = " + inceptionYear +" file: "
-                    + document.getFile().getAbsolutePath());
-        }
-        try {
-            Map<String, String> result = new HashMap<String, String>(4);
-            GitLookup gitLookup = getGitLookup(document.getFile(), properties);
-            int copyrightEnd = gitLookup.getYearOfLastChange(document.getFile());
-            result.put(COPYRIGHT_LAST_YEAR_KEY, Integer.toString(copyrightEnd));
-            final String copyrightYears;
-            if (inceptionYearInt >= copyrightEnd) {
-                copyrightYears = inceptionYear;
-            } else {
-                copyrightYears = inceptionYear + "-" + copyrightEnd;
-            }
-            result.put(COPYRIGHT_YEARS_KEY, copyrightYears);
 
-            int copyrightStart = gitLookup.getYearOfCreation(document.getFile());
-            result.put(COPYRIGHT_CREATION_YEAR_KEY, Integer.toString(copyrightStart));
+        try {
+            Map<String, String> result = new HashMap<String, String>(3);
+            GitLookup gitLookup = getGitLookup(document.getFile(), properties);
+
+            result.put(COPYRIGHT_CREATION_AUTHOR_NAME_KEY, gitLookup.getAuthorNameOfCreation(document.getFile()) );
+            result.put(COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY, gitLookup.getAuthorEmailOfCreation(document.getFile()) );
             return Collections.unmodifiableMap(result);
         } catch (Exception e) {
             throw new RuntimeException("Could not compute the year of the last git commit for file "
                     + document.getFile().getAbsolutePath(), e);
         }
     }
+
+ 
+
 }

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProvider.java
@@ -46,16 +46,9 @@ public class CopyrightAuthorProvider extends GitPropertiesProvider implements Pr
      * , whose values are set based on inspecting git history.
      *
      * <ul>
-     * <li>{@value #COPYRIGHT_LAST_YEAR_KEY} key stores the year from the committer date of the last git commit that has
-     * modified the supplied {@code document}.
-     * <li>{@value #COPYRIGHT_YEARS_KEY} key stores the range from {@value #INCEPTION_YEAR_KEY} value to
-     * {@value #COPYRIGHT_LAST_YEAR_KEY} value. If both values a equal, only the {@value #INCEPTION_YEAR_KEY} value is
-     * returned; otherwise, the two values are combined using dash, so that the result is e.g. {@code "2000 - 2010"}.
-     * <li>{@value #COPYRIGHT_CREATION_YEAR_KEY} key stores the year from the committer date of the first git commit for
-     * the supplied {@code document}.
+     * <li>{@value #COPYRIGHT_CREATION_AUTHOR_NAME_KEY} key stores the author name of the first git commit.
+     * <li>{@value #COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY} key stores the author's email address of the first git commit. 
      * </ul>
-     * The {@value #INCEPTION_YEAR_KEY} value is read from the supplied properties and it must available. Otherwise a
-     * {@link RuntimeException} is thrown.
      *
      */
     public Map<String, String> getAdditionalProperties(AbstractLicenseMojo mojo, Properties properties,

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitLookup.java
@@ -159,6 +159,32 @@ public class GitLookup {
         walk.dispose();
         return commitYear;
     }
+      
+    String getAuthorNameOfCreation(File file) throws IOException, GitAPIException {
+        String repoRelativePath = pathResolver.relativize(file);
+        String authorName = "";
+        RevWalk walk = getGitRevWalk(repoRelativePath, true);
+        Iterator<RevCommit> iterator = walk.iterator();
+        if (iterator.hasNext()) {
+            RevCommit commit = iterator.next();
+            authorName = getAuthorNameFromCommit(commit);
+        }
+        walk.dispose();
+        return authorName;
+    }
+    
+    String getAuthorEmailOfCreation(File file) throws IOException, GitAPIException {
+        String repoRelativePath = pathResolver.relativize(file);
+        String authorEmail = "";
+        RevWalk walk = getGitRevWalk(repoRelativePath, true);
+        Iterator<RevCommit> iterator = walk.iterator();
+        if (iterator.hasNext()) {
+            RevCommit commit = iterator.next();
+            authorEmail = getAuthorEmailFromCommit(commit);
+        }
+        walk.dispose();
+        return authorEmail;
+    }
 
     private boolean isFileModifiedOrUnstaged(String repoRelativePath) throws GitAPIException {
         Status status = new Git(repository).status().addPath(repoRelativePath).call();
@@ -205,5 +231,15 @@ public class GitLookup {
         Calendar result = Calendar.getInstance(timeZone);
         result.setTimeInMillis(epochMilliseconds);
         return result.get(Calendar.YEAR);
+    }
+    
+    private String getAuthorNameFromCommit(RevCommit commit){
+        PersonIdent id = commit.getAuthorIdent();
+        return id.getName();
+    }
+    
+    private String getAuthorEmailFromCommit(RevCommit commit){
+        PersonIdent id = commit.getAuthorIdent();
+        return id.getEmailAddress();
     }
 }

--- a/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPropertiesProvider.java
+++ b/license-maven-plugin-git/src/main/java/com/mycila/maven/plugin/license/git/GitPropertiesProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.TimeZone;
+
+/**
+ *
+ * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
+ */
+public class GitPropertiesProvider {
+    
+    private GitLookup gitLookup;
+    public static final String COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY = "license.git.copyrightLastYearMaxCommitsLookup";
+    public static final String COPYRIGHT_LAST_YEAR_SOURCE_KEY = "license.git.copyrightLastYearSource";
+    public static final String COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY = "license.git.copyrightLastYearTimeZone";
+    
+    public GitPropertiesProvider(){};
+
+    /**
+     * Lazily initializes #gitLookup assuming that all subsequent calls to this method will be related to the same
+     * git repository.
+     *
+     * @param file
+     * @return
+     * @throws IOException
+     */
+    GitLookup getGitLookup(File file, Properties props) throws IOException {
+        if (gitLookup == null) {
+            synchronized (this) {
+                if (gitLookup == null) {
+                    String dateSourceString = props.getProperty(COPYRIGHT_LAST_YEAR_SOURCE_KEY,
+                            GitLookup.DateSource.AUTHOR.name());
+                    GitLookup.DateSource dateSource = GitLookup.DateSource.valueOf(dateSourceString.toUpperCase(Locale.US));
+                    String checkCommitsCountString = props.getProperty(COPYRIGHT_LAST_YEAR_MAX_COMMITS_LOOKUP_KEY);
+                    int checkCommitsCount = GitLookup.DEFAULT_COMMITS_COUNT;
+                    if (checkCommitsCountString != null) {
+                        checkCommitsCountString = checkCommitsCountString.trim();
+                        checkCommitsCount = Integer.parseInt(checkCommitsCountString);
+                    }
+                    final TimeZone timeZone;
+                    String tzString = props.getProperty(COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY);
+                    switch (dateSource) {
+                    case COMMITER:
+                        timeZone = tzString == null ? GitLookup.DEFAULT_ZONE : TimeZone.getTimeZone(tzString);
+                        break;
+                    case AUTHOR:
+                        if (tzString != null) {
+                            throw new RuntimeException(COPYRIGHT_LAST_YEAR_TIME_ZONE_KEY + " must not be set with "
+                                    + COPYRIGHT_LAST_YEAR_SOURCE_KEY + " = " + GitLookup.DateSource.AUTHOR.name()
+                                    + " because git author name already contrains time zone information.");
+                        }
+                        timeZone = null;
+                        break;
+                    default:
+                        throw new IllegalStateException("Unexpected " + GitLookup.DateSource.class.getName() + " " + dateSource);
+                    }
+                    gitLookup = new GitLookup(file, dateSource, timeZone, checkCommitsCount);
+                }
+            }
+        }
+        return gitLookup;
+    }
+}

--- a/license-maven-plugin-git/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
+++ b/license-maven-plugin-git/src/main/resources/META-INF/services/com.mycila.maven.plugin.license.PropertiesProvider
@@ -1,1 +1,2 @@
 com.mycila.maven.plugin.license.git.CopyrightRangeProvider
+com.mycila.maven.plugin.license.git.CopyrightAuthorProvider

--- a/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
+++ b/license-maven-plugin-git/src/test/java/com/mycila/maven/plugin/license/git/CopyrightAuthorProviderTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license.git;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.mycila.maven.plugin.license.document.Document;
+
+/**
+ * @author <a href="mailto:ppalaga@redhat.com">Peter Palaga</a>
+ */
+public class CopyrightAuthorProviderTest {
+
+    private static File gitRepoRoot;
+    private static TemporaryFolder tempFolder;
+
+    @Test
+    public void copyrightAuthor() {
+        CopyrightAuthorProvider provider = new CopyrightAuthorProvider();
+
+        assertAuthor(provider, "dir1/file1.txt", "Peter Palaga", "ppalaga@redhat.com");
+    }
+
+    private void assertAuthor(CopyrightAuthorProvider provider, String path, String copyrightAuthorName, String copyrightAuthorEmail) {
+        Properties props = new Properties();
+
+        Document document = newDocument(path);
+        Map<String, String> actual = provider.getAdditionalProperties(null, props, document);
+
+        HashMap<String, String> expected = new HashMap<String, String>();
+        expected.put(CopyrightAuthorProvider.COPYRIGHT_CREATION_AUTHOR_NAME_KEY,  copyrightAuthorName);
+        expected.put(CopyrightAuthorProvider.COPYRIGHT_CREATION_AUTHOR_EMAIL_KEY, copyrightAuthorEmail);
+        Assert.assertEquals("for file '" + path + "': ", expected, actual);
+
+    }
+
+    private static Document newDocument(String relativePath) {
+        File file = new File(gitRepoRoot.getAbsolutePath() + File.separatorChar
+                + relativePath.replace('/', File.separatorChar));
+        return new Document(file, null, "utf-8", new String[0], null);
+    }
+
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        tempFolder = new TemporaryFolder();
+        tempFolder.create();
+
+        URL url = GitLookupTest.class.getResource("git-test-repo.zip");
+        File unzipDestination = tempFolder.getRoot();
+        gitRepoRoot = new File(unzipDestination, "git-test-repo");
+
+        GitLookupTest.unzip(url, unzipDestination);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        tempFolder.delete();
+    }
+
+}


### PR DESCRIPTION
Hi, I'm a user of your license maven plugin and git plugin.

I wanted to insert original author name and email address into license headers using git history,
so I made following patch for git plugin:
- added CopyrightAuthorProvider to treat author  information of first commit
- modified GitLookup.java to obtain author information from git history
- separated getGitLookup method from  CopyrightRangeProvider to GitPropertiesProvider base class.
- added unit test of CopyrightAuthorProvider

Could you review this PR when you're available?

Thank you.