### PR TITLE
Plugin configuration to support multi-licensing scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Available in OSS Repository:  https://oss.sonatype.org/content/repositories/snap
 
 __Plugin declaration__
 
+```xml
     <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
@@ -99,6 +100,49 @@ __Plugin declaration__
             </execution>
         </executions>
     </plugin>
+```
+
+__Plugin declaration ([Multi-Licensing](https://en.wikipedia.org/wiki/Multi-licensing))__
+
+If your source code makes use of multi-licensing, then instead of
+a `<header>` or `<inlineHeader>` element in the configuration
+you can use a `<multi>` element.
+
+The `<multi>` element allows you to specify an optional preamble,
+one or more header (or inlineHeader) and separators between them. These
+options are concatenated together to produce a header template.
+
+```xml
+    <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>X.Y.ga</version>
+        <configuration>
+            <multi>
+                <preamble><![CDATA[This product is dual-licensed under both the GPLv2 and Apache 2.0 License.]]></preamble>
+                <header>GPL-2.txt</header>
+                <separator>======================================================================</separator>
+                <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+            </multi>
+            <properties>
+                <owner>Mycila</owner>
+                <email>mathieu.carbou@gmail.com</email>
+            </properties>
+            <excludes>
+                <exclude>**/README</exclude>
+                <exclude>src/test/resources/**</exclude>
+                <exclude>src/main/resources/**</exclude>
+            </excludes>
+        </configuration>
+        <executions>
+            <execution>
+                <goals>
+                    <goal>check</goal>
+                </goals>
+            </execution>
+        </executions>
+    </plugin>
+```
 
 ## Documentation ##
 
@@ -150,7 +194,7 @@ You can find those license templates with preconfigured placeholders [here](http
 
 Properties which can be used as placeholder comes from:
 
- - Environnment variables
+ - Environment variables
  - POM properties
    - `project.groupId`
    - `project.artifactId`

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Multi.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Multi.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+public class Multi {
+
+    public static final String DEFAULT_SEPARATOR =
+            "---------------------------------------------------------------------";
+
+    /**
+     * Preamble text which if present is placed before the first header.
+     */
+    @Parameter
+    String preamble;
+
+    /**
+     * Location of each header. It can be a relative path, absolute path,
+     * classpath resource, any URL. The plugin first check if the name specified
+     * is a relative file, then an absolute file, then in the classpath. If not
+     * found, it tries to construct a URL from the location.
+     */
+    @Parameter(alias = "header")
+    String[] headers;
+
+    /**
+     * Header, as text, directly in pom file. Using a CDATA section is strongly recommended.
+     */
+    @Parameter(alias = "inlineHeader")
+    String[] inlineHeaders;
+
+    /**
+     * One of more separators between the headers.
+     * If there is only one separator it is placed between each header.
+     * If there are multiple separators, then the first separator is placed
+     * between the first and second license, the second separator is placed
+     * between the second and third license, and so on...
+     */
+    @Parameter(alias = "separator")
+    String[] separators;
+
+    public String getPreamble() {
+        return preamble;
+    }
+
+    public void setPreamble(final String preamble) {
+        this.preamble = preamble;
+    }
+
+    public String[] getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(final String[] headers) {
+        this.headers = headers;
+    }
+
+    public String[] getInlineHeaders() {
+        return inlineHeaders;
+    }
+
+    public void setInlineHeaders(final String[] inlineHeaders) {
+        this.inlineHeaders = inlineHeaders;
+    }
+
+    public String[] getSeparators() {
+        return separators;
+    }
+
+    public void setSeparators(final String[] separators) {
+        this.separators = separators;
+    }
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/header/HeaderSource.java
@@ -18,8 +18,12 @@ package com.mycila.maven.plugin.license.header;
 import java.io.IOException;
 import java.net.URL;
 
+import com.mycila.maven.plugin.license.Multi;
 import com.mycila.maven.plugin.license.util.FileUtils;
 import com.mycila.maven.plugin.license.util.resource.ResourceFinder;
+import org.apache.maven.plugin.MojoFailureException;
+
+import static com.mycila.maven.plugin.license.Multi.DEFAULT_SEPARATOR;
 
 /**
  * Provides an access to the license template text.
@@ -29,7 +33,7 @@ import com.mycila.maven.plugin.license.util.resource.ResourceFinder;
 public abstract class HeaderSource {
 
     /**
-     * A {@link HeaderSource} built from a lincense header template literal.
+     * A {@link HeaderSource} built from a license header template literal.
      */
     public static class LiteralHeaderSource extends HeaderSource {
         public LiteralHeaderSource(String content) {
@@ -74,6 +78,110 @@ public abstract class HeaderSource {
 
     }
 
+    /**
+     * A {@link HeaderSource} built from multiple license header template literals.
+     */
+    public static class MultiLiteralHeaderSource extends HeaderSource {
+        public MultiLiteralHeaderSource(final String preamble, final String[] contents, final String[] separators) {
+            super(combineHeaders(preamble, contents, separators), true);
+        }
+
+        /**
+         * @return always {@code false} because this {@link LiteralHeaderSource} was not loaded from any {@link URL}
+         */
+        @Override
+        public boolean isFromUrl(final URL location) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "inline: " + content;
+        }
+
+    }
+
+    /**
+     * A {@link HeaderSource} loaded from multiple {@link URL}.
+     */
+    public static class MultiUrlHeaderSource extends HeaderSource {
+        private final URL urls[];
+
+        public MultiUrlHeaderSource(final String preamble, final URL[] urls, final String[] separators, final String encoding) throws IOException {
+            super(combineHeaders(preamble, FileUtils.read(urls, encoding), separators), false);
+            this.urls = urls;
+        }
+
+        @Override
+        public boolean isFromUrl(final URL location) {
+            for (final URL url : urls) {
+                if (url.equals(location)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            builder.append('[');
+            for (final URL url : urls) {
+                if (builder.length() > 1) {
+                    builder.append(", ");
+                }
+                builder.append(url);
+            }
+            builder.append("] : ").append(content);
+            return builder.toString();
+        }
+
+    }
+
+    private static String combineHeaders(final String preamble, final String[] headers, final String[] separators) {
+        final StringBuilder builder = new StringBuilder();
+
+        // preamble
+        if (preamble != null) {
+            builder.append(preamble);
+            if (!preamble.endsWith("\n")) {
+                builder.append('\n');
+            }
+            builder.append('\n');
+        }
+
+        for (int i = 0; i < headers.length; i++) {
+
+            // separator
+            String separator = null;
+            if (i > 0) {
+                if (separators == null) {
+                    separator = DEFAULT_SEPARATOR;
+                } else if (separators.length == 1) {
+                    separator = separators[0];
+                } else {
+                    separator = separators[i - 1];
+                }
+
+                if (builder.charAt(builder.length() - 1) != '\n') {
+                    builder.append('\n');
+                }
+                builder.append('\n');
+                builder.append(separator);
+                if (!separator.endsWith("\n")) {
+                    builder.append('\n');
+                }
+                builder.append('\n');
+            }
+
+            // header
+            final String header = headers[i];
+            builder.append(header);
+        }
+
+        return builder.toString();
+    }
+
     public static HeaderSource of(String headerPath, String encoding, ResourceFinder finder) {
         return of(null, encoding, finder);
     }
@@ -83,24 +191,51 @@ public abstract class HeaderSource {
      * {@code inlineHeader} is not {@code null} returns a new {@link LiteralHeaderSource}. Otherwise attempts to create a
      * new {@link UrlHeaderSource} out of {@code headerPath} and {@code encoding}.
      *
-     * @param inlineHeader the text of a lincense header template
+     * @param multi container for multi license, or null if single license
+     * @param inlineHeader the text of a license header template
      * @param headerPath a path resolvable by the {@code finder}
-     * @param encoding the encoding to use when readinf {@code headerPath}
+     * @param encoding the encoding to use when reading {@code headerPath}
      * @param finder the {@link ResourceFinder} to use to resolve {@code headerPath}
      * @return a new {@link HeaderSource}
      */
-    public static HeaderSource of(String inlineHeader, String headerPath, String encoding, ResourceFinder finder) {
-        if (inlineHeader != null && !inlineHeader.isEmpty()) {
-            return new LiteralHeaderSource(inlineHeader);
-        } else if (headerPath == null) {
-            throw new IllegalArgumentException("Either inlineHeader or header path need to be specified");
+    public static HeaderSource of(Multi multi, String inlineHeader, String headerPath, String encoding, ResourceFinder finder) {
+        if (multi != null) {
+            if (multi.getInlineHeaders() != null && multi.getInlineHeaders().length > 0) {
+                return new MultiLiteralHeaderSource(multi.getPreamble(), multi.getInlineHeaders(), multi.getSeparators());
+            } else if (multi.getHeaders() == null || multi.getHeaders().length == 0) {
+                throw new IllegalArgumentException("Either multi/inlineHeader or multi/header path needs to be specified");
+            } else {
+                final URL[] headerUrls = new URL[multi.getHeaders().length];
+                for (int i = 0; i < multi.getHeaders().length; i++) {
+                    try {
+                        headerPath = multi.getHeaders()[i];
+                        final URL headerUrl = finder.findResource(headerPath);
+                        headerUrls[i] = headerUrl;
+                    } catch (final MojoFailureException e) {
+                        throw new IllegalArgumentException(
+                                "Cannot read header document " + headerPath + ". Cause: " + e.getMessage(), e);
+                    }
+                }
+                try {
+                    return new MultiUrlHeaderSource(multi.getPreamble(), headerUrls, multi.getSeparators(), encoding);
+                } catch (final IOException e) {
+                    throw new IllegalArgumentException(
+                            "Cannot read multi header documents. Cause: " + e.getMessage(), e);
+                }
+            }
         } else {
-            try {
-                final URL headerUrl = finder.findResource(headerPath);
-                return new UrlHeaderSource(headerUrl, encoding);
-            } catch (Exception e) {
-                throw new IllegalArgumentException(
-                        "Cannot read header document " + headerPath + ". Cause: " + e.getMessage(), e);
+            if (inlineHeader != null && !inlineHeader.isEmpty()) {
+                return new LiteralHeaderSource(inlineHeader);
+            } else if (headerPath == null) {
+                throw new IllegalArgumentException("Either inlineHeader or header path needs to be specified");
+            } else {
+                try {
+                    final URL headerUrl = finder.findResource(headerPath);
+                    return new UrlHeaderSource(headerUrl, encoding);
+                } catch (Exception e) {
+                    throw new IllegalArgumentException(
+                            "Cannot read header document " + headerPath + ". Cause: " + e.getMessage(), e);
+                }
             }
         }
     }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileUtils.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/util/FileUtils.java
@@ -61,6 +61,19 @@ public final class FileUtils {
         }
     }
 
+    public static String[] read(final URL[] locations, final String encoding) throws IOException {
+        final String[] results = new String[locations.length];
+        for (int i = 0; i < locations.length; i++) {
+            final Reader reader = new BufferedReader(new InputStreamReader(locations[i].openStream(), encoding));
+            try {
+                results[i] = IOUtil.toString(reader);
+            } finally {
+                reader.close();
+            }
+        }
+        return results;
+    }
+
     public static String read(File file, String encoding) throws IOException {
         FileChannel in = new FileInputStream(file).getChannel();
         try {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
@@ -98,5 +98,79 @@ public final class HeaderMojoTest {
         check.execute();
     }
 
+    @Test
+    public void test_load_multi_headers_from_relative_file() throws Exception {
+        final MavenProjectStub project = new MavenProjectStub();
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.basedir = new File("src/test/resources/check");
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"header.txt", "header2.txt"});
+        check.multi = multi;
+        check.project = project;
+        check.failIfMissing = false;
+        check.strictCheck = true;
+        check.execute();
+    }
+
+    @Test
+    public void test_load_multi_headers_from_absolute_file() throws Exception {
+        final MavenProjectStub project = new MavenProjectStub();
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.basedir = new File("src/test/resources/check");
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"src/test/resources/check/header.txt", "src/test/resources/check/header2.txt"});
+        check.multi = multi;
+        check.project = project;
+        check.failIfMissing = false;
+        check.strictCheck = true;
+        check.execute();
+    }
+
+    @Test
+    public void test_load_multi_headers_from_project_classpath() throws Exception {
+        final MavenProjectStub project = new MavenProjectStub();
+        project.addCompileSourceRoot("src/test/resources/check/cp");
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.basedir = new File("src/test/resources/check");
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"header-in-cp.txt", "header-in-cp.txt"});
+        check.multi = multi;
+        check.project = project;
+        check.failIfMissing = false;
+        check.strictCheck = true;
+        check.execute();
+    }
+
+    @Test
+    public void test_load_multi_headers_from_plugin_classpath() throws Exception {
+        final MavenProjectStub project = new MavenProjectStub();
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.basedir = new File("src/test/resources/check");
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"test-header1.txt", "test-header2.txt"});
+        check.multi = multi;
+        check.project = project;
+        check.failIfMissing = false;
+        check.strictCheck = true;
+        check.execute();
+    }
+
+    @Test
+    public void test_multi_inlineHeader() throws Exception {
+        final MavenProjectStub project = new MavenProjectStub();
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.basedir = new File("src/test/resources/check");
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {
+                FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8"),
+                FileUtils.read(new File("src/test/resources/check/header2.txt"), "utf-8")
+        });
+        check.multi = multi;
+        check.project = project;
+        check.failIfMissing = false;
+        check.strictCheck = true;
+        check.execute();
+    }
+
 
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderSourceTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/header/HeaderSourceTest.java
@@ -2,10 +2,13 @@ package com.mycila.maven.plugin.license.header;
 
 import java.io.File;
 
+import com.mycila.maven.plugin.license.Multi;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.mycila.maven.plugin.license.util.resource.ResourceFinder;
+
+import static com.mycila.maven.plugin.license.Multi.DEFAULT_SEPARATOR;
 
 public class HeaderSourceTest {
     
@@ -13,37 +16,211 @@ public class HeaderSourceTest {
 
     @Test
     public void testOfInline() {
-        HeaderSource actual = HeaderSource.of("inline header", "single-line-header.txt", "utf-8", finder);
+        HeaderSource actual = HeaderSource.of(null, "inline header", "single-line-header.txt", "utf-8", finder);
         Assert.assertEquals("inline header", actual.getContent());
         Assert.assertEquals(true, actual.isInline());
     }
 
     @Test
     public void testOfInlineOnly() {
-        HeaderSource actual = HeaderSource.of("inline header", null, null, null);
+        HeaderSource actual = HeaderSource.of(null, "inline header", null, null, null);
         Assert.assertEquals("inline header", actual.getContent());
         Assert.assertEquals(true, actual.isInline());
     }
 
     @Test
     public void testOfUrl() {
-        HeaderSource actual = HeaderSource.of(null, "single-line-header.txt", "utf-8", finder);
+        HeaderSource actual = HeaderSource.of(null, "", "single-line-header.txt", "utf-8", finder);
         Assert.assertEquals("just a one line header file for copyright", actual.getContent());
         Assert.assertEquals(false, actual.isInline());
-        
-        actual = HeaderSource.of("", "single-line-header.txt", "utf-8", finder);
+    }
+
+    @Test
+    public void testOfUrlOnly() {
+        HeaderSource actual = HeaderSource.of(null, null, "single-line-header.txt", "utf-8", finder);
         Assert.assertEquals("just a one line header file for copyright", actual.getContent());
         Assert.assertEquals(false, actual.isInline());
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testOfNulls() {
-        HeaderSource.of(null, null, "utf-8", finder);
+        HeaderSource.of(null, null, null, "utf-8", finder);
     }
 
     @Test(expected=IllegalArgumentException.class)
     public void testOfEmptyAndNull() {
-        HeaderSource.of("", null, "utf-8", finder);
+        HeaderSource.of(null, "", null, "utf-8", finder);
     }
 
+    @Test
+    public void testOfMultiInlineSingle() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[]{"multi inline header 1"});
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+        Assert.assertEquals("multi inline header 1", actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiInlineDouble() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {"multi inline header 1", "multi inline header 2"});
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+
+        final String expected = "multi inline header 1" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "multi inline header 2";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiInlineDoubleCustomSeparator() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {"multi inline header 1", "multi inline header 2"});
+        multi.setSeparators(new String[]{ "###"});
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+
+        final String expected = "multi inline header 1" + "\n\n"
+                + "###" + "\n\n" + "multi inline header 2";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiInlineTriple() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {"multi inline header 1", "multi inline header 2", "multi inline header 3"});
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+
+        final String expected = "multi inline header 1" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "multi inline header 2" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "multi inline header 3";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiInlineTripleCustomSeparator() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {"multi inline header 1", "multi inline header 2", "multi inline header 3"});
+        multi.setSeparators(new String[]{ "###" });
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+
+        final String expected = "multi inline header 1" + "\n\n"
+                + "###" + "\n\n" + "multi inline header 2" + "\n\n"
+                + "###" + "\n\n" + "multi inline header 3";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiInlineTripleCustomSeparators() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[] {"multi inline header 1", "multi inline header 2", "multi inline header 3"});
+        multi.setSeparators(new String[]{ "###", "*****" });
+        final HeaderSource actual = HeaderSource.of(multi, "inline header", "single-line-header.txt", "utf-8", finder);
+
+        final String expected = "multi inline header 1" + "\n\n"
+                + "###" + "\n\n" + "multi inline header 2" + "\n\n"
+                + "*****" + "\n\n" + "multi inline header 3";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(true, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlSingle() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt"});
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+        Assert.assertEquals("just a one line header file for copyright", actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlDouble() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt", "alternative-single-line-header.txt"});
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+
+        final String expected = "just a one line header file for copyright" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "alternative one line header file for copyright";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlDoubleCustomSeparator() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt", "alternative-single-line-header.txt"});
+        multi.setSeparators(new String[]{ "###"});
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+
+        final String expected = "just a one line header file for copyright" + "\n\n"
+                + "###" + "\n\n" + "alternative one line header file for copyright";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlTriple() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt", "alternative-single-line-header.txt", "single-line-header.txt"});
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+
+        final String expected = "just a one line header file for copyright" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "alternative one line header file for copyright" + "\n\n"
+                + DEFAULT_SEPARATOR + "\n\n" + "just a one line header file for copyright";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlTripleCustomSeparator() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt", "alternative-single-line-header.txt", "single-line-header.txt"});
+        multi.setSeparators(new String[]{ "###" });
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+
+        final String expected = "just a one line header file for copyright" + "\n\n"
+                + "###" + "\n\n" + "alternative one line header file for copyright" + "\n\n"
+                + "###" + "\n\n" + "just a one line header file for copyright";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test
+    public void testOfMultiUrlTripleCustomSeparators() {
+        final Multi multi = new Multi();
+        multi.setHeaders(new String[] {"single-line-header.txt", "alternative-single-line-header.txt", "single-line-header.txt"});
+        multi.setSeparators(new String[]{ "###", "*****" });
+        final HeaderSource actual = HeaderSource.of(multi, null, null, "utf-8", finder);
+
+        final String expected = "just a one line header file for copyright" + "\n\n"
+                + "###" + "\n\n" + "alternative one line header file for copyright" + "\n\n"
+                + "*****" + "\n\n" + "just a one line header file for copyright";
+
+        Assert.assertEquals(expected, actual.getContent());
+        Assert.assertEquals(false, actual.isInline());
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOfMultiNulls() {
+        HeaderSource.of(new Multi(), null, null, "utf-8", finder);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testOfMultiEmptyAndNull() {
+        final Multi multi = new Multi();
+        multi.setInlineHeaders(new String[0]);
+        HeaderSource.of(multi, "", null, "utf-8", finder);
+    }
 }

--- a/license-maven-plugin/src/test/resources/alternative-single-line-header.txt
+++ b/license-maven-plugin/src/test/resources/alternative-single-line-header.txt
@@ -1,0 +1,1 @@
+alternative one line header file for copyright


### PR DESCRIPTION
This adds support for source-code projects that use [multi-licensing](https://en.wikipedia.org/wiki/Multi-licensing) (e.g. dual-licensing).

If your source code makes use of multi-licensing, then instead of
a `<header>` or `<inlineHeader>` element in the configuration
you can use a `<multi>` element.

The `<multi>` element allows you to specify an optional preamble,
one or more header (or inlineHeader) and separators between them. These
options are concatenated together to produce a header template.

```xml
    <plugin>
        <groupId>com.mycila</groupId>
        <artifactId>license-maven-plugin</artifactId>
        <version>X.Y.ga</version>
        <configuration>
            <multi>
                <preamble><![CDATA[This product is dual-licensed under both the GPLv2 and Apache 2.0 License.]]></preamble>
                <header>GPL-2.txt</header>
                <separator>======================================================================</separator>
                <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
            </multi>
            <properties>
                <owner>Mycila</owner>
                <email>mathieu.carbou@gmail.com</email>
            </properties>
            <excludes>
                <exclude>**/README</exclude>
                <exclude>src/test/resources/**</exclude>
                <exclude>src/main/resources/**</exclude>
            </excludes>
        </configuration>
        <executions>
            <execution>
                <goals>
                    <goal>check</goal>
                </goals>
            </execution>
        </executions>
    </plugin>
```