### PR TITLE
Update default excludes for further CIs

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/Default.java
@@ -81,6 +81,10 @@ public final class Default {
         "**/.gitignore",
         "**/.gitmodules",
 
+        // GitHub
+        "**/.github",
+        "**/.github/**",
+
         // BitKeeper
         "**/BitKeeper",
         "**/BitKeeper/**",
@@ -172,6 +176,17 @@ public final class Default {
 
         // Travis
         "**/.travis.yml",
+
+        // AppVeyor
+        "**/.appveyor.yml",
+        "**/appveyor.yml",
+
+        // CircleCI
+        "**/.circleci",
+        "**/.circleci/**",
+
+        // SourceHut
+        "**/.build.yml",
 
         // flash
         "**/*.swf",


### PR DESCRIPTION
Adds support to exclude CI config files by default for:

* GitHub Actions
* AppVeyor
* CircleCI
* SourceHut