### PR TITLE
License Sets feature - allows one execution to check different licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ options are concatenated together to produce a header template.
 
 The detailed Maven Plugin Documentation generated for each build is available here:
 
+__NOTE__: Between versions 4.0 and 3.0 the configuration syntax has been changed. The
+plugin now has the concept of *License Sets*, which allow you to work with one or
+more license configurations in a single execution of the plugin. In simple terms, a `<licenseSet>`
+wraps the previous configuration options for a license. The previous
+configuration syntax is still supported but deprecated, and may be removed in future. 
+
  - [3.0](http://code.mycila.com/license-maven-plugin/reports/3.0/plugin-info.html)
  - [3.0.rc1](http://code.mycila.com/license-maven-plugin/reports/3.0.rc1/plugin-info.html)
  - [2.3](http://code.mycila.com/license-maven-plugin/reports/2.3/plugin-info.html)

--- a/README.md
+++ b/README.md
@@ -81,16 +81,20 @@ __Plugin declaration__
         <artifactId>license-maven-plugin</artifactId>
         <version>X.Y.ga</version>
         <configuration>
-            <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+            <licenseSets>
+                <licenseSet>
+                    <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                    <excludes>
+                        <exclude>**/README</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                    </excludes>
+                </licenseSet>
+            </licenseSets>
             <properties>
                 <owner>Mycila</owner>
                 <email>mathieu.carbou@gmail.com</email>
             </properties>
-            <excludes>
-                <exclude>**/README</exclude>
-                <exclude>src/test/resources/**</exclude>
-                <exclude>src/main/resources/**</exclude>
-            </excludes>
         </configuration>
         <executions>
             <execution>
@@ -118,21 +122,25 @@ options are concatenated together to produce a header template.
         <artifactId>license-maven-plugin</artifactId>
         <version>X.Y.ga</version>
         <configuration>
-            <multi>
-                <preamble><![CDATA[This product is dual-licensed under both the GPLv2 and Apache 2.0 License.]]></preamble>
-                <header>GPL-2.txt</header>
-                <separator>======================================================================</separator>
-                <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
-            </multi>
+            <licenseSets>
+                <licenseSet>
+                    <multi>
+                        <preamble><![CDATA[This product is dual-licensed under both the GPLv2 and Apache 2.0 License.]]></preamble>
+                        <header>GPL-2.txt</header>
+                        <separator>======================================================================</separator>
+                        <header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</header>
+                    </multi>
+                    <excludes>
+                        <exclude>**/README</exclude>
+                        <exclude>src/test/resources/**</exclude>
+                        <exclude>src/main/resources/**</exclude>
+                    </excludes>
+                </licenseSet>
+            </licenseSets>
             <properties>
                 <owner>Mycila</owner>
                 <email>mathieu.carbou@gmail.com</email>
             </properties>
-            <excludes>
-                <exclude>**/README</exclude>
-                <exclude>src/test/resources/**</exclude>
-                <exclude>src/main/resources/**</exclude>
-            </excludes>
         </configuration>
         <executions>
             <execution>

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -56,6 +56,7 @@
                 <configuration>
                     <excludes>
                         <exclude>src/test/**</exclude>
+                        <exclude>src/it/**</exclude>
                         <exclude>src/main/resources/**</exclude>
                     </excludes>
                 </configuration>
@@ -68,6 +69,32 @@
                         <sourceFileExclude>**/*Mojo.java</sourceFileExclude>
                     </sourceFileExcludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                    <preBuildHookScript>setup</preBuildHookScript>
+                    <postBuildHookScript>verify</postBuildHookScript>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-tests</id>
+                        <goals>
+                            <goal>install</goal>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                        <version>${junit.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/invoker.properties
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = license:format

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/mock-license-1.txt
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/mock-license-1.txt
@@ -1,0 +1,2 @@
+This is the 1st
+mock license

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/mock-license-2.txt
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/mock-license-2.txt
@@ -1,0 +1,2 @@
+This is the 2nd
+mock license

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/pom.xml
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/pom.xml
@@ -1,0 +1,53 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>legacy-config-and-license-set</artifactId>
+    <version>1.0.0</version>
+
+    <name>Check Legacy Configuration mixed with LicenseSet Configuration</name>
+    <description>Integration Test for checking legacy configuration when used with license set configuration</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+
+                    <!-- legacy config -->
+                    <header>mock-license-1.txt</header>
+                    <excludes>
+                        <exclude>invoker.properties</exclude>
+                        <exclude>pom.xml</exclude>
+                        <exclude>*.groovy</exclude>
+                        <exclude>**/*.bak</exclude>
+                        <exclude>*.log</exclude>
+                        <exclude>mock-license-*</exclude>
+                        <exclude>**/Unformatted2.java</exclude>
+                    </excludes>
+
+                    <!-- license sets config -->
+                    <licenseSets>
+                        <licenseSet>
+                            <header>mock-license-2.txt</header>
+                            <excludes>
+                                <exclude>invoker.properties</exclude>
+                                <exclude>pom.xml</exclude>
+                                <exclude>*.groovy</exclude>
+                                <exclude>**/*.bak</exclude>
+                                <exclude>*.log</exclude>
+                                <exclude>mock-license-*</exclude>
+                                <exclude>**/Unformatted1.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/setup.groovy
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/setup.groovy
@@ -1,0 +1,25 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Arrays
+import java.util.List
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final List<String> ALL_FILES = Arrays.asList("Unformatted1.java", "Unformatted2.java")
+
+for (final String filename : ALL_FILES) {
+    final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+    if (!Files.exists(unformattedJavaFile)) {
+        System.err.println(filename + " file is missing.")
+        return false
+    }
+
+    Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling(filename + ".bak"))
+}
+
+return true;

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/src/main/java/com/mycilla/it/Unformatted2.java
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/src/main/java/com/mycilla/it/Unformatted2.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted2 {
+}

--- a/license-maven-plugin/src/it/legacy-config-and-license-set/verify.groovy
+++ b/license-maven-plugin/src/it/legacy-config-and-license-set/verify.groovy
@@ -1,0 +1,53 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Arrays
+import java.util.List
+
+import static org.junit.Assert.*
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+for (int i = 1; i <= 2; i++) {
+
+    final Path license = base.resolve("mock-license-" + i + ".txt")
+    if (!Files.exists(license)) {
+        System.err.println(license.getFileName() + " file is missing.")
+        return false
+    }
+
+    final String filename = "Unformatted" + i + ".java"
+
+    final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename + ".bak")
+    if (!Files.exists(unformattedJavaFile)) {
+        System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+        return false
+    }
+
+    final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+    if (!Files.exists(formattedJavaFile)) {
+        System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+        return false
+    }
+
+    final StringBuilder expected = new StringBuilder();
+    expected.append("/*\n");
+    license.withReader { reader ->
+        while ((line = reader.readLine()) != null) {
+            expected.append(" * ").append(line).append('\n')
+        }
+    }
+    expected.append(" */\n")
+    expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+    final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+    assertEquals(expected.toString(), actual)
+}
+
+return true

--- a/license-maven-plugin/src/it/legacy-config/invoker.properties
+++ b/license-maven-plugin/src/it/legacy-config/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = license:format

--- a/license-maven-plugin/src/it/legacy-config/mock-license.txt
+++ b/license-maven-plugin/src/it/legacy-config/mock-license.txt
@@ -1,0 +1,2 @@
+This is a
+mock license

--- a/license-maven-plugin/src/it/legacy-config/pom.xml
+++ b/license-maven-plugin/src/it/legacy-config/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>legacy-config</artifactId>
+    <version>1.0.0</version>
+
+    <name>Check Legacy Configuration</name>
+    <description>Integration Test for checking legacy configuration</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <header>mock-license.txt</header>
+                    <excludes>
+                        <exclude>invoker.properties</exclude>
+                        <exclude>pom.xml</exclude>
+                        <exclude>*.groovy</exclude>
+                        <exclude>**/*.bak</exclude>
+                        <exclude>*.log</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/it/legacy-config/setup.groovy
+++ b/license-maven-plugin/src/it/legacy-config/setup.groovy
@@ -1,0 +1,19 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println("Unformatted1.java file is missing.")
+    return false
+}
+
+Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling("Unformatted1.java.bak"))
+
+return true;

--- a/license-maven-plugin/src/it/legacy-config/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/legacy-config/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/legacy-config/verify.groovy
+++ b/license-maven-plugin/src/it/legacy-config/verify.groovy
@@ -1,0 +1,46 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.junit.Assert.*
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final Path license = base.resolve("mock-license.txt")
+if (!Files.exists(license)) {
+    System.err.println("license file is missing.")
+    return false
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java.bak")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+    return false
+}
+
+final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(formattedJavaFile)) {
+    System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+    return false
+}
+
+final StringBuilder expected = new StringBuilder();
+expected.append("/*\n");
+license.withReader { reader ->
+    while ((line = reader.readLine()) != null) {
+        expected.append(" * ").append(line).append('\n')
+    }
+}
+expected.append(" */\n")
+expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+assertEquals(expected.toString(), actual)
+
+return true

--- a/license-maven-plugin/src/it/multi-license/invoker.properties
+++ b/license-maven-plugin/src/it/multi-license/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = license:format

--- a/license-maven-plugin/src/it/multi-license/mock-license-1.txt
+++ b/license-maven-plugin/src/it/multi-license/mock-license-1.txt
@@ -1,0 +1,2 @@
+This is the 1st
+mock license

--- a/license-maven-plugin/src/it/multi-license/mock-license-2.txt
+++ b/license-maven-plugin/src/it/multi-license/mock-license-2.txt
@@ -1,0 +1,2 @@
+This is the 2nd
+mock license

--- a/license-maven-plugin/src/it/multi-license/mock-license-3.txt
+++ b/license-maven-plugin/src/it/multi-license/mock-license-3.txt
@@ -1,0 +1,2 @@
+This is the 3rd
+mock license

--- a/license-maven-plugin/src/it/multi-license/pom.xml
+++ b/license-maven-plugin/src/it/multi-license/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>multi-license-set</artifactId>
+    <version>1.0.0</version>
+
+    <name>Check a Multi-License Set</name>
+    <description>Integration Test for checking a multi-license set</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <multi>
+                                <preamble><![CDATA[This product is multi-licensed under X, Y, Z licenses.]]></preamble>
+                                <header>mock-license-1.txt</header>
+                                <separator>*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#**#*#*#*#*#*#*</separator>
+                                <header>mock-license-2.txt</header>
+                                <separator>====================================================================</separator>
+                                <header>mock-license-3.txt</header>
+                            </multi>
+                            <excludes>
+                                <exclude>invoker.properties</exclude>
+                                <exclude>pom.xml</exclude>
+                                <exclude>*.groovy</exclude>
+                                <exclude>**/*.bak</exclude>
+                                <exclude>*.log</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/it/multi-license/setup.groovy
+++ b/license-maven-plugin/src/it/multi-license/setup.groovy
@@ -1,0 +1,19 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println("Unformatted1.java file is missing.")
+    return false
+}
+
+Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling("Unformatted1.java.bak"))
+
+return true;

--- a/license-maven-plugin/src/it/multi-license/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/multi-license/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/multi-license/verify.groovy
+++ b/license-maven-plugin/src/it/multi-license/verify.groovy
@@ -1,0 +1,70 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Arrays
+import java.util.List
+
+import static org.junit.Assert.*
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final String preamble = "This product is multi-licensed under X, Y, Z licenses."
+
+separators = [
+    "*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#**#*#*#*#*#*#*",
+    "===================================================================="
+]
+
+final StringBuilder expected = new StringBuilder()
+expected.append("/*\n")
+expected.append(" * ").append(preamble).append("\n")
+expected.append(" *\n")
+
+
+for (int i = 1; i <= 3; i++) {
+
+    final Path license = base.resolve("mock-license-" + i + ".txt")
+    if (!Files.exists(license)) {
+        System.err.println(license.getFileName() + " file is missing.")
+        return false
+    }
+
+    license.withReader { reader ->
+        while ((line = reader.readLine()) != null) {
+            expected.append(" * ").append(line).append('\n')
+        }
+    }
+
+    if (i < 3) {
+        final String separator = separators[i - 1]
+        expected.append(" *\n")
+        expected.append(" * ").append(separator).append('\n')
+        expected.append(" *\n")
+    }
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java.bak")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+    return false
+}
+
+expected.append(" */\n")
+expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(formattedJavaFile)) {
+    System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+    return false
+}
+
+final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+assertEquals(expected.toString(), actual)
+
+return true

--- a/license-maven-plugin/src/it/single-licence-set/invoker.properties
+++ b/license-maven-plugin/src/it/single-licence-set/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = license:format

--- a/license-maven-plugin/src/it/single-licence-set/mock-license.txt
+++ b/license-maven-plugin/src/it/single-licence-set/mock-license.txt
@@ -1,0 +1,2 @@
+This is a
+mock license

--- a/license-maven-plugin/src/it/single-licence-set/pom.xml
+++ b/license-maven-plugin/src/it/single-licence-set/pom.xml
@@ -1,0 +1,37 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>single-license-set</artifactId>
+    <version>1.0.0</version>
+
+    <name>Check a Single License Set</name>
+    <description>Integration Test for checking a single license set</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>mock-license.txt</header>
+                            <excludes>
+                                <exclude>invoker.properties</exclude>
+                                <exclude>pom.xml</exclude>
+                                <exclude>*.groovy</exclude>
+                                <exclude>**/*.bak</exclude>
+                                <exclude>*.log</exclude>
+                            </excludes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/it/single-licence-set/setup.groovy
+++ b/license-maven-plugin/src/it/single-licence-set/setup.groovy
@@ -1,0 +1,19 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println("Unformatted1.java file is missing.")
+    return false
+}
+
+Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling("Unformatted1.java.bak"))
+
+return true;

--- a/license-maven-plugin/src/it/single-licence-set/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/single-licence-set/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/single-licence-set/verify.groovy
+++ b/license-maven-plugin/src/it/single-licence-set/verify.groovy
@@ -1,0 +1,46 @@
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.junit.Assert.*
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final Path license = base.resolve("mock-license.txt")
+if (!Files.exists(license)) {
+    System.err.println("license file is missing.")
+    return false
+}
+
+final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java.bak")
+if (!Files.exists(unformattedJavaFile)) {
+    System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+    return false
+}
+
+final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/Unformatted1.java")
+if (!Files.exists(formattedJavaFile)) {
+    System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+    return false
+}
+
+final StringBuilder expected = new StringBuilder();
+expected.append("/*\n");
+license.withReader { reader ->
+    while ((line = reader.readLine()) != null) {
+        expected.append(" * ").append(line).append('\n')
+    }
+}
+expected.append(" */\n")
+expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+assertEquals(expected.toString(), actual)
+
+return true

--- a/license-maven-plugin/src/it/tri-license-set/invoker.properties
+++ b/license-maven-plugin/src/it/tri-license-set/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = license:format

--- a/license-maven-plugin/src/it/tri-license-set/mock-license-1.txt
+++ b/license-maven-plugin/src/it/tri-license-set/mock-license-1.txt
@@ -1,0 +1,2 @@
+This is the 1st
+mock license

--- a/license-maven-plugin/src/it/tri-license-set/mock-license-2.txt
+++ b/license-maven-plugin/src/it/tri-license-set/mock-license-2.txt
@@ -1,0 +1,2 @@
+This is the 2nd
+mock license

--- a/license-maven-plugin/src/it/tri-license-set/mock-license-3.txt
+++ b/license-maven-plugin/src/it/tri-license-set/mock-license-3.txt
@@ -1,0 +1,2 @@
+This is the 3rd
+mock license

--- a/license-maven-plugin/src/it/tri-license-set/pom.xml
+++ b/license-maven-plugin/src/it/tri-license-set/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycila.license-maven-plugin.it</groupId>
+    <artifactId>tri-license-set</artifactId>
+    <version>1.0.0</version>
+
+    <name>Check a Triple License Set</name>
+    <description>Integration Test for checking a triple license set</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>@project.version@</version>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>mock-license-1.txt</header>
+                            <excludes>
+                                <exclude>invoker.properties</exclude>
+                                <exclude>pom.xml</exclude>
+                                <exclude>*.groovy</exclude>
+                                <exclude>**/*.bak</exclude>
+                                <exclude>*.log</exclude>
+                                <exclude>mock-license-*</exclude>
+                                <exclude>**/Unformatted2.java</exclude>
+                                <exclude>**/Unformatted3.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                        <licenseSet>
+                            <header>mock-license-2.txt</header>
+                            <excludes>
+                                <exclude>invoker.properties</exclude>
+                                <exclude>pom.xml</exclude>
+                                <exclude>*.groovy</exclude>
+                                <exclude>**/*.bak</exclude>
+                                <exclude>*.log</exclude>
+                                <exclude>mock-license-*</exclude>
+                                <exclude>**/Unformatted1.java</exclude>
+                                <exclude>**/Unformatted3.java</exclude>
+                            </excludes>
+                        </licenseSet>
+                        <licenseSet>
+                            <header>mock-license-3.txt</header>
+                            <includes>
+                                <include>**/Unformatted3.java</include>
+                            </includes>
+                        </licenseSet>
+                    </licenseSets>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/license-maven-plugin/src/it/tri-license-set/setup.groovy
+++ b/license-maven-plugin/src/it/tri-license-set/setup.groovy
@@ -1,0 +1,25 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Arrays
+import java.util.List
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+final List<String> ALL_FILES = Arrays.asList("Unformatted1.java", "Unformatted2.java", "Unformatted3.java")
+
+for (final String filename : ALL_FILES) {
+    final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+    if (!Files.exists(unformattedJavaFile)) {
+        System.err.println(filename + " file is missing.")
+        return false
+    }
+
+    Files.copy(unformattedJavaFile, unformattedJavaFile.resolveSibling(filename + ".bak"))
+}
+
+return true;

--- a/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted1.java
+++ b/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted1.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted1 {
+}

--- a/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted2.java
+++ b/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted2.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted2 {
+}

--- a/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted3.java
+++ b/license-maven-plugin/src/it/tri-license-set/src/main/java/com/mycilla/it/Unformatted3.java
@@ -1,0 +1,4 @@
+package com.mycila.it;
+
+public class Unformatted3 {
+}

--- a/license-maven-plugin/src/it/tri-license-set/verify.groovy
+++ b/license-maven-plugin/src/it/tri-license-set/verify.groovy
@@ -1,0 +1,53 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Arrays
+import java.util.List
+
+import static org.junit.Assert.*
+
+
+final Path base = basedir.toPath()
+
+if (!Files.exists(base) || !Files.isDirectory(base)) {
+    System.err.println("base directory is missing.")
+    return false
+}
+
+for (int i = 1; i <= 3; i++) {
+
+    final Path license = base.resolve("mock-license-" + i + ".txt")
+    if (!Files.exists(license)) {
+        System.err.println(license.getFileName() + " file is missing.")
+        return false
+    }
+
+    final String filename = "Unformatted" + i + ".java"
+
+    final Path unformattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename + ".bak")
+    if (!Files.exists(unformattedJavaFile)) {
+        System.err.println(unformattedJavaFile.getFileName() + " file is missing (should have been created by setup.groovy).")
+        return false
+    }
+
+    final Path formattedJavaFile = base.resolve("src/main/java/com/mycilla/it/" + filename)
+    if (!Files.exists(formattedJavaFile)) {
+        System.err.println(formattedJavaFile.getFileName() + " file is missing.")
+        return false
+    }
+
+    final StringBuilder expected = new StringBuilder();
+    expected.append("/*\n");
+    license.withReader { reader ->
+        while ((line = reader.readLine()) != null) {
+            expected.append(" * ").append(line).append('\n')
+        }
+    }
+    expected.append(" */\n")
+    expected.append(new String(Files.readAllBytes(unformattedJavaFile)))
+
+    final String actual = new String(Files.readAllBytes(formattedJavaFile))
+
+    assertEquals(expected.toString(), actual)
+}
+
+return true

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -44,16 +44,7 @@ import org.xml.sax.InputSource;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
@@ -72,26 +63,35 @@ import static java.util.Arrays.deepToString;
  */
 public abstract class AbstractLicenseMojo extends AbstractMojo {
 
+    @Parameter
+    public LicenseSet[] licenseSets;
+
     /**
      * The base directory, in which to search for project files.
      */
-    @Parameter(property = "license.basedir", defaultValue = "${basedir}", required = true)
-    public File basedir;
+    @Parameter(property = "license.basedir", defaultValue = "${basedir}", alias = "basedir", required = true)
+    public File baseBasedir;
 
     /**
      * Location of the header. It can be a relative path, absolute path,
      * classpath resource, any URL. The plugin first check if the name specified
      * is a relative file, then an absolute file, then in the classpath. If not
      * found, it tries to construct a URL from the location.
+     *
+     * @deprecated use {@link LicenseSet#header}
      */
-    @Parameter(property = "license.header")
-    public String header;
+    @Deprecated
+    @Parameter(property = "license.header", alias = "header")
+    public String legacyConfigHeader;
 
     /**
      * Header, as text, directly in pom file. Using a CDATA section is strongly recommended.
+     *
+     * @deprecated use {@link LicenseSet#inlineHeader}
      */
-    @Parameter(property = "license.inlineHeader")
-    public String inlineHeader;
+    @Deprecated
+    @Parameter(property = "license.inlineHeader", alias="inlineHeader")
+    public String legacyConfigInlineHeader;
 
     /**
      * Specifies additional header files to use when checking for the presence
@@ -102,9 +102,12 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      * <br>
      * When using remove goal, this property will be used to detect all valid
      * headers that also must be removed.
+     *
+     * @deprecated use {@link LicenseSet#validHeaders}
      */
-    @Parameter
-    public String[] validHeaders = new String[0];
+    @Deprecated
+    @Parameter(alias = "validHeaders")
+    public String[] legacyConfigValidHeaders = new String[0];
 
     /**
      * Alternative to `header`, `inlineHeader`, or `validHeaders`
@@ -114,23 +117,29 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      * and have them concatenated together by the plugin. This
      * allows you to maintain each distinct license header in
      * its own file and combined them in different ways.
+     *
+     * @deprecated use {@link LicenseSet#multi}
      */
+    @Deprecated
     @Parameter
-    public Multi multi;
+    public Multi legacyConfigMulti;
 
     /**
      * Allows the use of external header definitions files. These files are
      * properties like files.
      */
-    @Parameter
-    public String[] headerDefinitions = new String[0];
+    @Parameter(alias = "headerDefinitions")
+    public String[] baseHeaderDefinitions = new String[0];
 
     /**
      * HeadSections define special regions of a header that allow for dynamic
      * substitution and validation
+     *
+     * @deprecated use {@link LicenseSet#headerSections}
      */
-    @Parameter
-    public HeaderSection[] headerSections = new HeaderSection[0];
+    @Deprecated
+    @Parameter(alias = "headerSections")
+    public HeaderSection[] legacyConfigHeaderSections = new HeaderSection[0];
 
     /**
      * You can set here some properties that you want to use when reading the
@@ -139,38 +148,47 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      * replaced when the header file is read by those you specified in the
      * command line, in the POM and in system environment.
      */
-    @Parameter
-    public Map<String, String> properties = new HashMap<String, String>();
+    @Parameter(alias = "properties")
+    public Map<String, String> baseProperties = new HashMap<String, String>();
 
     /**
      * Specifies files, which are included in the check. By default, all files
      * are included.
+     *
+     * @deprecated use {@link LicenseSet#includes}
      */
-    @Parameter(property = "license.includes")
-    public String[] includes = new String[0];
+    @Deprecated
+    @Parameter(alias = "includes", property = "license.includes")
+    public String[] legacyConfigIncludes = new String[0];
 
     /**
      * Specifies files, which are excluded in the check. By default, only the
      * files matching the default exclude patterns are excluded.
+     *
+     * @deprecated use {@link LicenseSet#excludes}
      */
-    @Parameter(property = "license.excludes")
-    public String[] excludes = new String[0];
+    @Deprecated
+    @Parameter(alias = "excludes", property = "license.excludes")
+    public String[] legacyConfigExcludes = new String[0];
 
     /**
      * Specify the list of keywords to use to detect a header. A header must
      * include all keywords to be valid. By default, the word 'copyright' is
      * used. Detection is done case insensitive.
+     *
+     * @deprecated use {@link LicenseSet#keywords}
      */
-    @Parameter
-    public String[] keywords = new String[]{"copyright"};
+    @Deprecated
+    @Parameter(alias = "keywords")
+    public String[] legacyConfigKeywords = new String[]{"copyright"};
 
     /**
      * Specify if you want to use default exclusions besides the files you have
      * excluded. Default exclusions exclude CVS and SVN folders, IDE descriptors
      * and so on.
      */
-    @Parameter(property = "license.useDefaultExcludes", defaultValue = "true")
-    public boolean useDefaultExcludes = true;
+    @Parameter(property = "license.useDefaultExcludes", defaultValue = "true", alias = "useDefaultExcludes")
+    public boolean baseUseDefaultExcludes = true;
 
     /**
      * You can set this flag to true if you want to check the headers for all
@@ -302,8 +320,6 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     @Component
     private SettingsDecrypter settingsDecrypter;
 
-    private ResourceFinder finder;
-
     protected abstract class AbstractCallback implements Callback {
 
         /**
@@ -333,146 +349,201 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     @SuppressWarnings({"unchecked"})
     public final void execute(final Callback callback) throws MojoExecutionException, MojoFailureException {
         if (!skip) {
-            if (!hasHeader()) {
-                warn("No header file specified to check for license");
-                return;
-            }
-            if (!strictCheck) {
-                warn("Property 'strictCheck' is not enabled. Please consider adding <strictCheck>true</strictCheck> in your pom.xml file.");
-                warn("See http://mycila.github.io/license-maven-plugin for more information.");
-            }
 
-            finder = new ResourceFinder(basedir);
-            try {
-                finder.setCompileClassPath(project.getCompileClasspathElements());
-            } catch (DependencyResolutionRequiredException e) {
-                throw new MojoExecutionException(e.getMessage(), e);
-            }
-            finder.setPluginClassPath(getClass().getClassLoader());
+            // collect all the license sets together
+            final LicenseSet[] allLicenseSets;
 
-            final HeaderSource headerSource = HeaderSource.of(this.multi, this.inlineHeader, this.header, this.encoding, this.finder);
-            final Header h = new Header(headerSource, headerSections);
-            debug("Header: %s", h.getLocation());
-
-            if (this.validHeaders == null) {
-                this.validHeaders = new String[0];
-            }
-            final List<Header> validHeaders = new ArrayList<Header>(this.validHeaders.length);
-            for (String validHeader : this.validHeaders) {
-                final HeaderSource validHeaderSource = HeaderSource.of(null, null, validHeader, this.encoding, this.finder);
-                validHeaders.add(new Header(validHeaderSource, headerSections));
-            }
-
-            final List<PropertiesProvider> propertiesProviders = new LinkedList<PropertiesProvider>();
-            for (PropertiesProvider provider : ServiceLoader.load(PropertiesProvider.class, Thread.currentThread().getContextClassLoader())) {
-                propertiesProviders.add(provider);
-            }
-            final DocumentPropertiesLoader propertiesLoader = new DocumentPropertiesLoader() {
-                @Override
-                public Properties load(Document document) {
-                    Properties props = new Properties();
-
-                    for (Map.Entry<String, String> entry : mergeProperties(document).entrySet()) {
-                        if (entry.getValue() != null) {
-                            props.setProperty(entry.getKey(), entry.getValue());
-                        } else {
-                            props.remove(entry.getKey());
-                        }
-                    }
-                    for (PropertiesProvider provider : propertiesProviders) {
-                        try {
-                            final Map<String, String> providerProperties = provider.getAdditionalProperties(AbstractLicenseMojo.this, props, document);
-                            if (getLog().isDebugEnabled()) {
-                                getLog().debug("provider: " + provider.getClass() + " brought new properties\n" + providerProperties);
-                            }
-                            for (Map.Entry<String, String> entry : providerProperties.entrySet()) {
-                                if (entry.getValue() != null) {
-                                    props.setProperty(entry.getKey(), entry.getValue());
-                                } else {
-                                    props.remove(entry.getKey());
-                                }
-                            }
-                        } catch (Exception e) {
-                            getLog().warn("failure occured while calling " + provider.getClass(), e);
-                        }
-                    }
-                    return props;
+            // if we abandon the legacy config this contiguous block can be removed
+            final LicenseSet legacyLicenseSet = convertLegacyConfigToLicenseSet();
+            if (legacyLicenseSet != null) {
+                if (licenseSets == null) {
+                    allLicenseSets = new LicenseSet[]{legacyLicenseSet};
+                } else {
+                    allLicenseSets = Arrays.copyOf(licenseSets, licenseSets.length + 1);
+                    allLicenseSets[licenseSets.length] = legacyLicenseSet;
                 }
-            };
-
-            final DocumentFactory documentFactory = new DocumentFactory(basedir, buildMapping(), buildHeaderDefinitions(), encoding, keywords, propertiesLoader);
-
-            int nThreads = getNumberOfExecutorThreads();
-            ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
-            CompletionService completionService = new ExecutorCompletionService(executorService);
-            int count = 0;
-            debug("Number of execution threads: %s", nThreads);
-
-            try {
-                for (final String file : listSelectedFiles()) {
-                    completionService.submit(new Runnable() {
-                        @Override
-                        public void run() {
-                            Document document = documentFactory.createDocuments(file);
-                            debug("Selected file: %s [header style: %s]", document.getFilePath(), document.getHeaderDefinition());
-                            if (document.isNotSupported()) {
-                                callback.onUnknownFile(document, h);
-                            } else if (document.is(h)) {
-                                debug("Skipping header file: %s", document.getFilePath());
-                            } else if (document.hasHeader(h, strictCheck)) {
-                                callback.onExistingHeader(document, h);
-                            } else {
-                                boolean headerFound = false;
-                                for (Header validHeader : validHeaders) {
-                                    if (headerFound = document.hasHeader(validHeader, strictCheck)) {
-                                        callback.onExistingHeader(document, h);
-                                        break;
-                                    }
-                                }
-                                if (!headerFound) {
-                                    callback.onHeaderNotFound(document, h);
-                                }
-                            }
-                        }
-                    }, null);
-                    count++;
-                }
-
-                while (count-- > 0) {
-                    try {
-                        completionService.take().get();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    } catch (ExecutionException e) {
-                        Throwable cause = e.getCause();
-                        if (cause instanceof Error) {
-                            throw (Error) cause;
-                        }
-                        if (cause instanceof MojoExecutionException) {
-                            throw (MojoExecutionException) cause;
-                        }
-                        if (cause instanceof MojoFailureException) {
-                            throw (MojoFailureException) cause;
-                        }
-                        if (cause instanceof RuntimeException) {
-                            throw (RuntimeException) cause;
-                        }
-                        throw new RuntimeException(cause.getMessage(), cause);
-                    }
-                }
-
-            } finally {
-                executorService.shutdownNow();
+            } else {
+                allLicenseSets = licenseSets;
             }
+
+            // execute
+            executeForLicenseSets(allLicenseSets, callback);
         }
     }
 
-    private boolean hasHeader() {
+    private void executeForLicenseSets(final LicenseSet[] licenseSets, final Callback callback) throws MojoFailureException, MojoExecutionException {
+        if (licenseSets == null || licenseSets.length == 0) {
+            warn("At least one licenseSet must be specified");
+            return;
+        }
+
+        // need to perform validation first
+        for (int i = 0 ; i < licenseSets.length; i++) {
+            final LicenseSet licenseSet = licenseSets[i];
+            if (!hasHeader(licenseSet)) {
+                warn("No header file specified to check for license in licenseSet: " + i);
+                return;
+            }
+        }
+        if (!strictCheck) {
+            warn("Property 'strictCheck' is not enabled. Please consider adding <strictCheck>true</strictCheck> in your pom.xml file.");
+            warn("See http://mycila.github.io/license-maven-plugin for more information.");
+        }
+
+        // then execute each license set
+        for (final LicenseSet licenseSet : licenseSets) {
+            executeForLicenseSet(licenseSet, callback);
+        }
+    }
+
+    private LicenseSet convertLegacyConfigToLicenseSet() {
+        if (legacyConfigHeader == null && (this.legacyConfigInlineHeader == null || this.legacyConfigInlineHeader.isEmpty())) {
+            return null;
+        }
+
+        final LicenseSet legacyLicenseSet = new LicenseSet();
+        legacyLicenseSet.header = legacyConfigHeader;
+        legacyLicenseSet.inlineHeader = legacyConfigInlineHeader;
+        legacyLicenseSet.validHeaders = legacyConfigValidHeaders;
+        legacyLicenseSet.multi = legacyConfigMulti;
+        legacyLicenseSet.headerSections = legacyConfigHeaderSections;
+        legacyLicenseSet.includes = legacyConfigIncludes;
+        legacyLicenseSet.excludes = legacyConfigExcludes;
+        legacyLicenseSet.keywords = legacyConfigKeywords;
+        return legacyLicenseSet;
+    }
+
+    private void executeForLicenseSet(final LicenseSet licenseSet, final Callback callback) throws MojoExecutionException, MojoFailureException {
+        final ResourceFinder finder = new ResourceFinder(firstNonNull(licenseSet.basedir, baseBasedir));
+        try {
+            finder.setCompileClassPath(project.getCompileClasspathElements());
+        } catch (DependencyResolutionRequiredException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+        finder.setPluginClassPath(getClass().getClassLoader());
+
+        final HeaderSource headerSource = HeaderSource.of(licenseSet.multi, licenseSet.inlineHeader, licenseSet.header, this.encoding, finder);
+        final Header h = new Header(headerSource, licenseSet.headerSections);
+        debug("Header: %s", h.getLocation());
+
+        if (licenseSet.validHeaders == null) {
+            licenseSet.validHeaders = new String[0];
+        }
+        final List<Header> validHeaders = new ArrayList<Header>(licenseSet.validHeaders.length);
+        for (final String validHeader : licenseSet.validHeaders) {
+            final HeaderSource validHeaderSource = HeaderSource.of(null, null, validHeader, this.encoding, finder);
+            validHeaders.add(new Header(validHeaderSource, licenseSet.headerSections));
+        }
+
+        final List<PropertiesProvider> propertiesProviders = new LinkedList<PropertiesProvider>();
+        for (final PropertiesProvider provider : ServiceLoader.load(PropertiesProvider.class, Thread.currentThread().getContextClassLoader())) {
+            propertiesProviders.add(provider);
+        }
+        final DocumentPropertiesLoader propertiesLoader = new DocumentPropertiesLoader() {
+            @Override
+            public Properties load(final Document document) {
+                final Properties props = new Properties();
+
+                for (final Map.Entry<String, String> entry : mergeProperties(licenseSet, document).entrySet()) {
+                    if (entry.getValue() != null) {
+                        props.setProperty(entry.getKey(), entry.getValue());
+                    } else {
+                        props.remove(entry.getKey());
+                    }
+                }
+                for (final PropertiesProvider provider : propertiesProviders) {
+                    try {
+                        final Map<String, String> providerProperties = provider.getAdditionalProperties(AbstractLicenseMojo.this, props, document);
+                        if (getLog().isDebugEnabled()) {
+                            getLog().debug("provider: " + provider.getClass() + " brought new properties\n" + providerProperties);
+                        }
+                        for (Map.Entry<String, String> entry : providerProperties.entrySet()) {
+                            if (entry.getValue() != null) {
+                                props.setProperty(entry.getKey(), entry.getValue());
+                            } else {
+                                props.remove(entry.getKey());
+                            }
+                        }
+                    } catch (Exception e) {
+                        getLog().warn("failure occurred while calling " + provider.getClass(), e);
+                    }
+                }
+                return props;
+            }
+        };
+
+        final DocumentFactory documentFactory = new DocumentFactory(firstNonNull(licenseSet.basedir, baseBasedir), buildMapping(), buildHeaderDefinitions(licenseSet, finder), encoding, licenseSet.keywords, propertiesLoader);
+
+        int nThreads = getNumberOfExecutorThreads();
+        ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
+        CompletionService completionService = new ExecutorCompletionService(executorService);
+        int count = 0;
+        debug("Number of execution threads: %s", nThreads);
+
+        try {
+            for (final String file : listSelectedFiles(licenseSet)) {
+                completionService.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        Document document = documentFactory.createDocuments(file);
+                        debug("Selected file: %s [header style: %s]", document.getFilePath(), document.getHeaderDefinition());
+                        if (document.isNotSupported()) {
+                            callback.onUnknownFile(document, h);
+                        } else if (document.is(h)) {
+                            debug("Skipping header file: %s", document.getFilePath());
+                        } else if (document.hasHeader(h, strictCheck)) {
+                            callback.onExistingHeader(document, h);
+                        } else {
+                            boolean headerFound = false;
+                            for (final Header validHeader : validHeaders) {
+                                if (headerFound = document.hasHeader(validHeader, strictCheck)) {
+                                    callback.onExistingHeader(document, h);
+                                    break;
+                                }
+                            }
+                            if (!headerFound) {
+                                callback.onHeaderNotFound(document, h);
+                            }
+                        }
+                    }
+                }, null);
+                count++;
+            }
+
+            while (count-- > 0) {
+                try {
+                    completionService.take().get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    if (cause instanceof Error) {
+                        throw (Error) cause;
+                    }
+                    if (cause instanceof MojoExecutionException) {
+                        throw (MojoExecutionException) cause;
+                    }
+                    if (cause instanceof MojoFailureException) {
+                        throw (MojoFailureException) cause;
+                    }
+                    if (cause instanceof RuntimeException) {
+                        throw (RuntimeException) cause;
+                    }
+                    throw new RuntimeException(cause.getMessage(), cause);
+                }
+            }
+
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private boolean hasHeader(final LicenseSet licenseSet) {
         return
-                (multi != null
-                        && ((multi.headers != null && multi.headers.length > 0)
-                        || (multi.inlineHeaders != null && multi.inlineHeaders.length > 0 && !multi.inlineHeaders[0].isEmpty()))
-                ) || (header != null || (inlineHeader != null && !this.inlineHeader.isEmpty()));
+                (licenseSet.multi != null
+                        && ((licenseSet.multi.headers != null && licenseSet.multi.headers.length > 0)
+                        || (licenseSet.multi.inlineHeaders != null && licenseSet.multi.inlineHeaders.length > 0 && !licenseSet.multi.inlineHeaders[0].isEmpty()))
+                ) || (licenseSet.header != null || (licenseSet.inlineHeader != null && !licenseSet.inlineHeader.isEmpty()));
     }
 
     private int getNumberOfExecutorThreads() {
@@ -481,8 +552,8 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
             Math.max(1, (int) (Runtime.getRuntime().availableProcessors() * concurrencyFactor));
     }
 
-    private Map<String, String> mergeProperties(Document document) {
-        // first put systen environment
+    private Map<String, String> mergeProperties(final LicenseSet licenseSet, final Document document) {
+        // first put system environment
         Map<String, String> props = new LinkedHashMap<String, String>(System.getenv());
         // then add ${project.XYZ} properties
         props.put("project.groupId", project.getGroupId());
@@ -494,10 +565,17 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
         props.put("project.url", project.getUrl());
         // then add per document properties
         props.put("file.name", document.getFile().getName());
+
         // we override by properties in the POM
-        if (this.properties != null) {
-            props.putAll(this.properties);
+        if (this.baseProperties != null) {
+            props.putAll(this.baseProperties);
         }
+
+        // we override by properties in the licenseSet
+        if (licenseSet.properties != null) {
+            props.putAll(licenseSet.properties);
+        }
+
         // then we override by java system properties (command-line -D...)
         for (String key : System.getProperties().stringPropertyNames()) {
             props.put(key, System.getProperty(key));
@@ -505,17 +583,18 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
         return props;
     }
 
-    private String[] listSelectedFiles() {
-        Selection selection = new Selection(basedir, includes, buildExcludes(), useDefaultExcludes);
-        debug("From: %s", basedir);
+    private String[] listSelectedFiles(final LicenseSet licenseSet) {
+        final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes : baseUseDefaultExcludes);
+        final Selection selection = new Selection(firstNonNull(licenseSet.basedir, baseBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes);
+        debug("From: %s", firstNonNull(licenseSet.basedir, baseBasedir));
         debug("Including: %s", deepToString(selection.getIncluded()));
         debug("Excluding: %s", deepToString(selection.getExcluded()));
         return selection.getSelectedFiles();
     }
 
-    private String[] buildExcludes() {
+    private String[] buildExcludes(final LicenseSet licenseSet) {
         List<String> ex = new ArrayList<String>();
-        ex.addAll(asList(this.excludes));
+        ex.addAll(asList(licenseSet.excludes));
         if (project != null && project.getModules() != null && !aggregate) {
             for (String module : (List<String>) project.getModules()) {
                 ex.add(module + "/**");
@@ -559,25 +638,36 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
         return extensionMapping;
     }
 
-    private Map<String, HeaderDefinition> buildHeaderDefinitions() throws MojoFailureException {
+    private Map<String, HeaderDefinition> buildHeaderDefinitions(final LicenseSet licenseSet, final ResourceFinder finder) throws MojoFailureException {
         // like mappings, first get default definitions
         final Map<String, HeaderDefinition> headers = new HashMap<String, HeaderDefinition>(HeaderType.defaultDefinitions());
-        // and then override them with those provided in properties file
-        for (String resource : headerDefinitions) {
-            try {
-                InputSource source = new InputSource(finder.findResource(resource).openStream());
-                source.setEncoding(encoding);
-                final AdditionalHeaderDefinition fileDefinitions = new AdditionalHeaderDefinition(XMLDoc.from(source, true));
-                final Map<String, HeaderDefinition> map = fileDefinitions.getDefinitions();
-                debug("%d header definitions loaded from '%s'", map.size(), resource);
-                headers.putAll(map);
-            } catch (IOException ex) {
-                throw new MojoFailureException("Error reading header definition: " + resource, ex);
-            }
+
+        // and then override them with those provided in base config
+        for (final String headerDefiniton : baseHeaderDefinitions) {
+            headers.putAll(loadHeaderDefinition(headerDefiniton, finder));
         }
-        // force inclusion of unknow item to manage unknown files
+
+        // and then override them with those provided in licenseSet config
+        for (final String headerDefiniton : licenseSet.headerDefinitions) {
+            headers.putAll(loadHeaderDefinition(headerDefiniton, finder));
+        }
+
+        // force inclusion of unknown item to manage unknown files
         headers.put(HeaderType.UNKNOWN.getDefinition().getType(), HeaderType.UNKNOWN.getDefinition());
         return headers;
+    }
+
+    private Map<String, HeaderDefinition> loadHeaderDefinition(final String headerDefinition, final ResourceFinder finder) throws MojoFailureException {
+        try {
+            final InputSource source = new InputSource(finder.findResource(headerDefinition).openStream());
+            source.setEncoding(encoding);
+            final AdditionalHeaderDefinition fileDefinitions = new AdditionalHeaderDefinition(XMLDoc.from(source, true));
+            final Map<String, HeaderDefinition> map = fileDefinitions.getDefinitions();
+            debug("%d header definitions loaded from '%s'", map.size(), headerDefinition);
+            return map;
+        } catch (final IOException ex) {
+            throw new MojoFailureException("Error reading header definition: " + headerDefinition, ex);
+        }
     }
 
     /**
@@ -618,5 +708,12 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
             return null;
         }
         return str.replaceAll(".", "*");
+    }
+
+    private static <T> T firstNonNull(final T t1, final T t2) {
+        if (t1 != null) {
+            return t1;
+        }
+        return t2;
     }
 }

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -68,9 +68,13 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
     /**
      * The base directory, in which to search for project files.
+     *
+     * This is named `defaultBaseDirectory` as it will be used as the default
+     * value for the base directory. This default value can be overridden
+     * in each LicenseSet by setting {@link LicenseSet#basedir}.
      */
     @Parameter(property = "license.basedir", defaultValue = "${basedir}", alias = "basedir", required = true)
-    public File baseBasedir;
+    public File defaultBasedir;
 
     /**
      * Location of the header. It can be a relative path, absolute path,
@@ -127,9 +131,13 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     /**
      * Allows the use of external header definitions files. These files are
      * properties like files.
+     *
+     * This is named `defaultHeaderDefinitions` as it will be used as the default
+     * value for the header definitions. This default value can be overridden
+     * in each LicenseSet by setting {@link LicenseSet#headerDefinitions}.
      */
     @Parameter(alias = "headerDefinitions")
-    public String[] baseHeaderDefinitions = new String[0];
+    public String[] defaultHeaderDefinitions = new String[0];
 
     /**
      * HeadSections define special regions of a header that allow for dynamic
@@ -147,9 +155,13 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      * ${year}, ${owner} or whatever you want for the name. They will be
      * replaced when the header file is read by those you specified in the
      * command line, in the POM and in system environment.
+     *
+     * This is named `defaultProperties` as it will be used as the default
+     * value for the properties. This default value can be overridden
+     * in each LicenseSet by setting {@link LicenseSet#properties}.
      */
     @Parameter(alias = "properties")
-    public Map<String, String> baseProperties = new HashMap<String, String>();
+    public Map<String, String> defaultProperties = new HashMap<String, String>();
 
     /**
      * Specifies files, which are included in the check. By default, all files
@@ -186,9 +198,13 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
      * Specify if you want to use default exclusions besides the files you have
      * excluded. Default exclusions exclude CVS and SVN folders, IDE descriptors
      * and so on.
+     *
+     * This is named `defaultUseDefaultExcludes` as it will be used as the default
+     * value for whether to use default excludes. This default value can be overridden
+     * in each LicenseSet by setting {@link LicenseSet#useDefaultExcludes}.
      */
     @Parameter(property = "license.useDefaultExcludes", defaultValue = "true", alias = "useDefaultExcludes")
-    public boolean baseUseDefaultExcludes = true;
+    public boolean defaultUseDefaultExcludes = true;
 
     /**
      * You can set this flag to true if you want to check the headers for all
@@ -414,7 +430,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     }
 
     private void executeForLicenseSet(final LicenseSet licenseSet, final Callback callback) throws MojoExecutionException, MojoFailureException {
-        final ResourceFinder finder = new ResourceFinder(firstNonNull(licenseSet.basedir, baseBasedir));
+        final ResourceFinder finder = new ResourceFinder(firstNonNull(licenseSet.basedir, defaultBasedir));
         try {
             finder.setCompileClassPath(project.getCompileClasspathElements());
         } catch (DependencyResolutionRequiredException e) {
@@ -472,7 +488,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
             }
         };
 
-        final DocumentFactory documentFactory = new DocumentFactory(firstNonNull(licenseSet.basedir, baseBasedir), buildMapping(), buildHeaderDefinitions(licenseSet, finder), encoding, licenseSet.keywords, propertiesLoader);
+        final DocumentFactory documentFactory = new DocumentFactory(firstNonNull(licenseSet.basedir, defaultBasedir), buildMapping(), buildHeaderDefinitions(licenseSet, finder), encoding, licenseSet.keywords, propertiesLoader);
 
         int nThreads = getNumberOfExecutorThreads();
         ExecutorService executorService = Executors.newFixedThreadPool(nThreads);
@@ -567,8 +583,8 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
         props.put("file.name", document.getFile().getName());
 
         // we override by properties in the POM
-        if (this.baseProperties != null) {
-            props.putAll(this.baseProperties);
+        if (this.defaultProperties != null) {
+            props.putAll(this.defaultProperties);
         }
 
         // we override by properties in the licenseSet
@@ -584,9 +600,9 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
     }
 
     private String[] listSelectedFiles(final LicenseSet licenseSet) {
-        final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes : baseUseDefaultExcludes);
-        final Selection selection = new Selection(firstNonNull(licenseSet.basedir, baseBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes);
-        debug("From: %s", firstNonNull(licenseSet.basedir, baseBasedir));
+        final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes : defaultUseDefaultExcludes);
+        final Selection selection = new Selection(firstNonNull(licenseSet.basedir, defaultBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes);
+        debug("From: %s", firstNonNull(licenseSet.basedir, defaultBasedir));
         debug("Including: %s", deepToString(selection.getIncluded()));
         debug("Excluding: %s", deepToString(selection.getExcluded()));
         return selection.getSelectedFiles();
@@ -643,7 +659,7 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
         final Map<String, HeaderDefinition> headers = new HashMap<String, HeaderDefinition>(HeaderType.defaultDefinitions());
 
         // and then override them with those provided in base config
-        for (final String headerDefiniton : baseHeaderDefinitions) {
+        for (final String headerDefiniton : defaultHeaderDefinitions) {
             headers.putAll(loadHeaderDefinition(headerDefiniton, finder));
         }
 

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseSet.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2008 Mycila (mathieu.carbou@gmail.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.mycila.maven.plugin.license;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class LicenseSet {
+
+    /**
+     * The base directory, in which to search for project files.
+     */
+    @Parameter(property = "license.basedir")
+    public File basedir;
+
+    /**
+     * Location of the header. It can be a relative path, absolute path,
+     * classpath resource, any URL. The plugin first check if the name specified
+     * is a relative file, then an absolute file, then in the classpath. If not
+     * found, it tries to construct a URL from the location.
+     */
+    @Parameter(property = "license.header")
+    public String header;
+
+    /**
+     * Header, as text, directly in pom file. Using a CDATA section is strongly recommended.
+     */
+    @Parameter(property = "license.inlineHeader")
+    public String inlineHeader;
+
+    /**
+     * Specifies additional header files to use when checking for the presence
+     * of a valid header in your sources.
+     * <br>
+     * When using format goal, this property will be used to detect all valid
+     * headers that don't need formatting.
+     * <br>
+     * When using remove goal, this property will be used to detect all valid
+     * headers that also must be removed.
+     */
+    @Parameter
+    public String[] validHeaders = new String[0];
+
+    /**
+     * Alternative to `header`, `inlineHeader`, or `validHeaders`
+     * for use when code is multi-licensed.
+     * Whilst you could create a concatenated header yourself,
+     * a cleaner approach may be to specify more than one header
+     * and have them concatenated together by the plugin. This
+     * allows you to maintain each distinct license header in
+     * its own file and combined them in different ways.
+     */
+    @Parameter
+    public Multi multi;
+
+    /**
+     * Allows the use of external header definitions files. These files are
+     * properties like files.
+     */
+    @Parameter
+    public String[] headerDefinitions = new String[0];
+
+    /**
+     * HeadSections define special regions of a header that allow for dynamic
+     * substitution and validation
+     */
+    @Parameter
+    public HeaderSection[] headerSections = new HeaderSection[0];
+
+    /**
+     * You can set here some properties that you want to use when reading the
+     * header file. You can use in your header file some properties like
+     * ${year}, ${owner} or whatever you want for the name. They will be
+     * replaced when the header file is read by those you specified in the
+     * command line, in the POM and in system environment.
+     */
+    @Parameter
+    public Map<String, String> properties = new HashMap<String, String>();
+
+    /**
+     * Specifies files, which are included in the check. By default, all files
+     * are included.
+     */
+    @Parameter
+    public String[] includes = new String[0];
+
+    /**
+     * Specifies files, which are excluded in the check. By default, only the
+     * files matching the default exclude patterns are excluded.
+     */
+    @Parameter
+    public String[] excludes = new String[0];
+
+    /**
+     * Specify the list of keywords to use to detect a header. A header must
+     * include all keywords to be valid. By default, the word 'copyright' is
+     * used. Detection is done case insensitive.
+     */
+    @Parameter
+    public String[] keywords = new String[]{"copyright"};
+
+    /**
+     * Specify if you want to use default exclusions besides the files you have
+     * excluded. Default exclusions exclude CVS and SVN folders, IDE descriptors
+     * and so on.
+     */
+    @Parameter(property = "license.useDefaultExcludes")
+    public Boolean useDefaultExcludes;
+
+}

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/document/DocumentFactory.java
@@ -34,7 +34,7 @@ public final class DocumentFactory {
     private final String[] keywords;
     private final DocumentPropertiesLoader documentPropertiesLoader;
 
-    public DocumentFactory(File basedir, Map<String, String> mapping, Map<String, HeaderDefinition> definitions, String encoding, String[] keywords, DocumentPropertiesLoader documentPropertiesLoader) {
+    public DocumentFactory(final File basedir, final Map<String, String> mapping, final Map<String, HeaderDefinition> definitions, final String encoding, final String[] keywords, final DocumentPropertiesLoader documentPropertiesLoader) {
         this.mapping = mapping;
         this.definitions = definitions;
         this.basedir = basedir;
@@ -43,11 +43,11 @@ public final class DocumentFactory {
         this.documentPropertiesLoader = documentPropertiesLoader;
     }
 
-    public Document createDocuments(String file) {
+    public Document createDocuments(final String file) {
         return getWrapper(file);
     }
 
-    private Document getWrapper(String file) {
+    private Document getWrapper(final String file) {
         String headerType = mapping.get("");
         String lowerFileName = FileUtils.filename(file).toLowerCase();
         for (Map.Entry<String, String> entry : mapping.entrySet()) {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
@@ -31,10 +31,10 @@ public final class AdditionalHeaderMojoTest {
     @Test
     public void test_additionalHeaderDefinitions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/def");
-        check.header = "src/test/resources/check/header.txt";
+        check.baseBasedir = new File("src/test/resources/check/def");
+        check.legacyConfigHeader = "src/test/resources/check/header.txt";
         check.project = new MavenProjectStub();
-        check.excludes = new String[]{"*.xml"};
+        check.legacyConfigExcludes = new String[]{"*.xml"};
         check.strictCheck = true;
 
         try {
@@ -44,7 +44,7 @@ public final class AdditionalHeaderMojoTest {
             assertEquals("Some files do not have the expected license header", e.getMessage());
         }
 
-        check.headerDefinitions = new String[]{"/check/def/additionalHeaderDefinitions.xml"};
+        check.baseHeaderDefinitions = new String[]{"/check/def/additionalHeaderDefinitions.xml"};
         check.execute();
     }
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AdditionalHeaderMojoTest.java
@@ -31,7 +31,7 @@ public final class AdditionalHeaderMojoTest {
     @Test
     public void test_additionalHeaderDefinitions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/def");
+        check.defaultBasedir = new File("src/test/resources/check/def");
         check.legacyConfigHeader = "src/test/resources/check/header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigExcludes = new String[]{"*.xml"};
@@ -44,7 +44,7 @@ public final class AdditionalHeaderMojoTest {
             assertEquals("Some files do not have the expected license header", e.getMessage());
         }
 
-        check.baseHeaderDefinitions = new String[]{"/check/def/additionalHeaderDefinitions.xml"};
+        check.defaultHeaderDefinitions = new String[]{"/check/def/additionalHeaderDefinitions.xml"};
         check.execute();
     }
 }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
@@ -39,7 +39,7 @@ public final class AggregateMojoTest {
             }
         };
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/modules");
+        check.defaultBasedir = new File("src/test/resources/check/modules");
         check.legacyConfigHeader = "header.txt";
         check.project = project;
         check.strictCheck = true;
@@ -56,7 +56,7 @@ public final class AggregateMojoTest {
         };
         LicenseCheckMojo check = new LicenseCheckMojo();
         check.project = project;
-        check.baseBasedir = new File("src/test/resources/check/modules");
+        check.defaultBasedir = new File("src/test/resources/check/modules");
         check.legacyConfigHeader = "header.txt";
         check.aggregate = true;
         check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/AggregateMojoTest.java
@@ -39,8 +39,8 @@ public final class AggregateMojoTest {
             }
         };
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/modules");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check/modules");
+        check.legacyConfigHeader = "header.txt";
         check.project = project;
         check.strictCheck = true;
         check.execute();
@@ -56,8 +56,8 @@ public final class AggregateMojoTest {
         };
         LicenseCheckMojo check = new LicenseCheckMojo();
         check.project = project;
-        check.basedir = new File("src/test/resources/check/modules");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check/modules");
+        check.legacyConfigHeader = "header.txt";
         check.aggregate = true;
         check.strictCheck = true;
         try {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -34,8 +34,8 @@ public final class CheckTest {
         MavenProjectStub project = new MavenProjectStub();
 
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/linewrap");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check/linewrap");
+        check.legacyConfigHeader = "header.txt";
         check.project = project;
 
         // check by default - should work
@@ -56,16 +56,16 @@ public final class CheckTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/check/linewrap/testconfig.xml"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/check/linewrap/header.txt";
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
         updater.project = project;
         updater.strictCheck = true;
         updater.execute();
 
         // the check again, strictly. should work now
         check = new LicenseCheckMojo();
-        check.basedir = tmp;
-        check.header = "src/test/resources/check/linewrap/header.txt";
+        check.baseBasedir = tmp;
+        check.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
         check.project = project;
 
         check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/CheckTest.java
@@ -34,7 +34,7 @@ public final class CheckTest {
         MavenProjectStub project = new MavenProjectStub();
 
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/linewrap");
+        check.defaultBasedir = new File("src/test/resources/check/linewrap");
         check.legacyConfigHeader = "header.txt";
         check.project = project;
 
@@ -56,7 +56,7 @@ public final class CheckTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/check/linewrap/testconfig.xml"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
         updater.project = project;
         updater.strictCheck = true;
@@ -64,7 +64,7 @@ public final class CheckTest {
 
         // the check again, strictly. should work now
         check = new LicenseCheckMojo();
-        check.baseBasedir = tmp;
+        check.defaultBasedir = tmp;
         check.legacyConfigHeader = "src/test/resources/check/linewrap/header.txt";
         check.project = project;
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
@@ -29,10 +29,10 @@ public final class ExcludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_no_exclusions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.excludes = new String[0];
+        check.legacyConfigExcludes = new String[0];
         check.strictCheck = true;
         check.execute();
     }
@@ -40,10 +40,10 @@ public final class ExcludesMojoTest {
     @Test
     public void test_exclusions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.excludes = new String[]{"**/*.txt", "**/*.xml", "**/*.java", "**/*.apt.vm"};
+        check.legacyConfigExcludes = new String[]{"**/*.txt", "**/*.xml", "**/*.java", "**/*.apt.vm"};
         check.strictCheck = true;
         check.execute();
     }

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ExcludesMojoTest.java
@@ -29,7 +29,7 @@ public final class ExcludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_no_exclusions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigExcludes = new String[0];
@@ -40,7 +40,7 @@ public final class ExcludesMojoTest {
     @Test
     public void test_exclusions() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigExcludes = new String[]{"**/*.txt", "**/*.xml", "**/*.java", "**/*.apt.vm"};

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/FailIfMissingMojoTest.java
@@ -29,7 +29,7 @@ public final class FailIfMissingMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_fail() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.strictCheck = true;
@@ -39,7 +39,7 @@ public final class FailIfMissingMojoTest {
     @Test
     public void test_not_fail() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.failIfMissing = false;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
@@ -31,7 +31,7 @@ public final class HeaderMojoTest {
     public void test_create() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/main/resources/check");
+        check.baseBasedir = new File("src/main/resources/check");
         check.project = project;
         check.strictCheck = true;
         check.execute();
@@ -41,8 +41,8 @@ public final class HeaderMojoTest {
     public void test_load_header_from_relative_file() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -53,8 +53,8 @@ public final class HeaderMojoTest {
     public void test_load_header_from_absolute_file() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "src/test/resources/check/header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "src/test/resources/check/header.txt";
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -66,8 +66,8 @@ public final class HeaderMojoTest {
         MavenProjectStub project = new MavenProjectStub();
         project.addCompileSourceRoot("src/test/resources/check/cp");
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header-in-cp.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header-in-cp.txt";
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -78,8 +78,8 @@ public final class HeaderMojoTest {
     public void test_load_header_from_plugin_classpath() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "test-header1.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "test-header1.txt";
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -90,8 +90,8 @@ public final class HeaderMojoTest {
     public void test_inlineHeader() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.inlineHeader = FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8");
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8");
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -102,10 +102,10 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_relative_file() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
+        check.baseBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"header.txt", "header2.txt"});
-        check.multi = multi;
+        check.legacyConfigMulti = multi;
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -116,10 +116,10 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_absolute_file() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
+        check.baseBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"src/test/resources/check/header.txt", "src/test/resources/check/header2.txt"});
-        check.multi = multi;
+        check.legacyConfigMulti = multi;
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -131,10 +131,10 @@ public final class HeaderMojoTest {
         final MavenProjectStub project = new MavenProjectStub();
         project.addCompileSourceRoot("src/test/resources/check/cp");
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
+        check.baseBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"header-in-cp.txt", "header-in-cp.txt"});
-        check.multi = multi;
+        check.legacyConfigMulti = multi;
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -145,10 +145,10 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_plugin_classpath() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
+        check.baseBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"test-header1.txt", "test-header2.txt"});
-        check.multi = multi;
+        check.legacyConfigMulti = multi;
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;
@@ -159,13 +159,13 @@ public final class HeaderMojoTest {
     public void test_multi_inlineHeader() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
+        check.baseBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setInlineHeaders(new String[] {
                 FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8"),
                 FileUtils.read(new File("src/test/resources/check/header2.txt"), "utf-8")
         });
-        check.multi = multi;
+        check.legacyConfigMulti = multi;
         check.project = project;
         check.failIfMissing = false;
         check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/HeaderMojoTest.java
@@ -31,7 +31,7 @@ public final class HeaderMojoTest {
     public void test_create() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/main/resources/check");
+        check.defaultBasedir = new File("src/main/resources/check");
         check.project = project;
         check.strictCheck = true;
         check.execute();
@@ -41,7 +41,7 @@ public final class HeaderMojoTest {
     public void test_load_header_from_relative_file() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = project;
         check.failIfMissing = false;
@@ -53,7 +53,7 @@ public final class HeaderMojoTest {
     public void test_load_header_from_absolute_file() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "src/test/resources/check/header.txt";
         check.project = project;
         check.failIfMissing = false;
@@ -66,7 +66,7 @@ public final class HeaderMojoTest {
         MavenProjectStub project = new MavenProjectStub();
         project.addCompileSourceRoot("src/test/resources/check/cp");
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header-in-cp.txt";
         check.project = project;
         check.failIfMissing = false;
@@ -78,7 +78,7 @@ public final class HeaderMojoTest {
     public void test_load_header_from_plugin_classpath() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "test-header1.txt";
         check.project = project;
         check.failIfMissing = false;
@@ -90,7 +90,7 @@ public final class HeaderMojoTest {
     public void test_inlineHeader() throws Exception {
         MavenProjectStub project = new MavenProjectStub();
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8");
         check.project = project;
         check.failIfMissing = false;
@@ -102,7 +102,7 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_relative_file() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"header.txt", "header2.txt"});
         check.legacyConfigMulti = multi;
@@ -116,7 +116,7 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_absolute_file() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"src/test/resources/check/header.txt", "src/test/resources/check/header2.txt"});
         check.legacyConfigMulti = multi;
@@ -131,7 +131,7 @@ public final class HeaderMojoTest {
         final MavenProjectStub project = new MavenProjectStub();
         project.addCompileSourceRoot("src/test/resources/check/cp");
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"header-in-cp.txt", "header-in-cp.txt"});
         check.legacyConfigMulti = multi;
@@ -145,7 +145,7 @@ public final class HeaderMojoTest {
     public void test_load_multi_headers_from_plugin_classpath() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setHeaders(new String[] {"test-header1.txt", "test-header2.txt"});
         check.legacyConfigMulti = multi;
@@ -159,7 +159,7 @@ public final class HeaderMojoTest {
     public void test_multi_inlineHeader() throws Exception {
         final MavenProjectStub project = new MavenProjectStub();
         final LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         final Multi multi = new Multi();
         multi.setInlineHeaders(new String[] {
                 FileUtils.read(new File("src/test/resources/check/header.txt"), "utf-8"),

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
@@ -29,7 +29,7 @@ public final class IncludesMojoTest {
     @Test
     public void test_include() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"inexisting"};
@@ -40,7 +40,7 @@ public final class IncludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_include_and_fail() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"doc1.txt"};
@@ -51,7 +51,7 @@ public final class IncludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_include_overrides_default_exclusion() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/issues/issue-71");
+        check.defaultBasedir = new File("src/test/resources/issues/issue-71");
         check.legacyConfigHeader = "../../check/header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"**/.travis.yml"};

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/IncludesMojoTest.java
@@ -29,10 +29,10 @@ public final class IncludesMojoTest {
     @Test
     public void test_include() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"inexisting"};
+        check.legacyConfigIncludes = new String[]{"inexisting"};
         check.strictCheck = true;
         check.execute();
     }
@@ -40,10 +40,10 @@ public final class IncludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_include_and_fail() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"doc1.txt"};
+        check.legacyConfigIncludes = new String[]{"doc1.txt"};
         check.strictCheck = true;
         check.execute();
     }
@@ -51,10 +51,10 @@ public final class IncludesMojoTest {
     @Test(expected = MojoExecutionException.class)
     public void test_include_overrides_default_exclusion() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/issues/issue-71");
-        check.header = "../../check/header.txt";
+        check.baseBasedir = new File("src/test/resources/issues/issue-71");
+        check.legacyConfigHeader = "../../check/header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"**/.travis.yml"};
+        check.legacyConfigIncludes = new String[]{"**/.travis.yml"};
         check.execute();
     }
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/LicenseSetTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/LicenseSetTest.java
@@ -15,35 +15,32 @@
  */
 package com.mycila.maven.plugin.license;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.junit.Test;
 
 import java.io.File;
 
-/**
- * @author Mathieu Carbou (mathieu.carbou@gmail.com)
- */
-public final class FailIfMissingMojoTest {
-
-    @Test(expected = MojoExecutionException.class)
-    public void test_fail() throws Exception {
-        LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
-        check.legacyConfigHeader = "header.txt";
-        check.project = new MavenProjectStub();
-        check.strictCheck = true;
-        check.execute();
-    }
+public class LicenseSetTest {
 
     @Test
-    public void test_not_fail() throws Exception {
-        LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
-        check.legacyConfigHeader = "header.txt";
+    public void multipleLicenseSets() throws Exception {
+        final LicenseSet licenseSet1 = new LicenseSet();
+        licenseSet1.basedir = new File("src/test/resources/check/strict");
+        licenseSet1.header = "src/test/resources/test-header1-diff.txt";
+
+        final LicenseSet licenseSet2 = new LicenseSet();
+        licenseSet2.basedir = new File("src/test/resources/check/issue76");
+        licenseSet2.header = "src/test/resources/test-header1.txt";
+
+        final LicenseSet[] licenseSets = {
+                licenseSet1,
+                licenseSet2
+        };
+
+        final LicenseCheckMojo check = new LicenseCheckMojo();
+        check.licenseSets = licenseSets;
         check.project = new MavenProjectStub();
-        check.failIfMissing = false;
-        check.strictCheck = true;
+        check.strictCheck = false;
         check.execute();
     }
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
@@ -37,8 +37,8 @@ public final class MappingMojoTest {
         LicenseCheckMojo check = new LicenseCheckMojo();
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = true;
         check.strictCheck = true;
@@ -74,11 +74,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"test.apt.vm"};
-        check.properties = new HashMap<String, String>() {{
+        check.legacyConfigIncludes = new String[]{"test.apt.vm"};
+        check.baseProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -105,11 +105,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.basedir = new File("src/test/resources/check/issue107");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check/issue107");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"test.xml.tmpl"};
-        check.properties = new HashMap<String, String>() {{
+        check.legacyConfigIncludes = new String[]{"test.xml.tmpl"};
+        check.baseProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -131,11 +131,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.basedir = new File("src/test/resources/extensionless");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/extensionless");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"extensionless-file"};
-        check.properties = new HashMap<String, String>() {{
+        check.legacyConfigIncludes = new String[]{"extensionless-file"};
+        check.baseProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -168,11 +168,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.basedir = new File("src/test/resources/unknown");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/unknown");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.includes = new String[]{"file.unknown"};
-        check.properties = new HashMap<String, String>() {{
+        check.legacyConfigIncludes = new String[]{"file.unknown"};
+        check.baseProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
         check.failIfUnknown = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/MappingMojoTest.java
@@ -37,7 +37,7 @@ public final class MappingMojoTest {
         LicenseCheckMojo check = new LicenseCheckMojo();
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = true;
@@ -74,11 +74,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"test.apt.vm"};
-        check.baseProperties = new HashMap<String, String>() {{
+        check.defaultProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -105,11 +105,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.baseBasedir = new File("src/test/resources/check/issue107");
+        check.defaultBasedir = new File("src/test/resources/check/issue107");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"test.xml.tmpl"};
-        check.baseProperties = new HashMap<String, String>() {{
+        check.defaultProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -131,11 +131,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.baseBasedir = new File("src/test/resources/extensionless");
+        check.defaultBasedir = new File("src/test/resources/extensionless");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"extensionless-file"};
-        check.baseProperties = new HashMap<String, String>() {{
+        check.defaultProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
 
@@ -168,11 +168,11 @@ public final class MappingMojoTest {
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));
         //check.setLog(new SystemStreamLog());
-        check.baseBasedir = new File("src/test/resources/unknown");
+        check.defaultBasedir = new File("src/test/resources/unknown");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.legacyConfigIncludes = new String[]{"file.unknown"};
-        check.baseProperties = new HashMap<String, String>() {{
+        check.defaultProperties = new HashMap<String, String>() {{
             put("year", "2008");
         }};
         check.failIfUnknown = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
@@ -32,7 +32,7 @@ public final class QuietMojoTest {
     @Test
     public void test_load_header_from_relative_file() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.failIfMissing = false;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/QuietMojoTest.java
@@ -32,12 +32,12 @@ public final class QuietMojoTest {
     @Test
     public void test_load_header_from_relative_file() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.failIfMissing = false;
         check.strictCheck = true;
-        check.excludes = new String[]{"**/issue107/**"};
+        check.legacyConfigExcludes = new String[]{"**/issue107/**"};
 
         MockedLog logger = new MockedLog();
         check.setLog(new DefaultLog(logger));

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
@@ -42,8 +42,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/doc2.txt"), tmp);
         
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
 
@@ -59,8 +59,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/doc/doc3.txt"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
 
@@ -80,8 +80,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/issue44-3.rb"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
 
@@ -97,8 +97,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/test.xml"), tmp);
         
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
 
@@ -114,8 +114,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/test.js"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
 
@@ -134,8 +134,8 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/issue-30/one-line-comment.ftl"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "src/test/resources/remove/header.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
         
@@ -154,15 +154,15 @@ public final class RemoveMojoTest {
 
         // Let's apply the licene
         LicenseFormatMojo format = new LicenseFormatMojo();
-        format.basedir = tmp;
-        format.header = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
+        format.baseBasedir = tmp;
+        format.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
         format.project = new MavenProjectStub();
         format.execute();
         
         // Let's try to remove it
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.basedir = tmp;
-        remove.header = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
+        remove.baseBasedir = tmp;
+        remove.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
         remove.project = new MavenProjectStub();
 //        remove.keywords = new String[]{"GNU"};
         remove.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/RemoveMojoTest.java
@@ -42,7 +42,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/doc2.txt"), tmp);
         
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -59,7 +59,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/doc/doc3.txt"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -80,7 +80,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/issue44-3.rb"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -97,7 +97,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/test.xml"), tmp);
         
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -114,7 +114,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/test.js"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -134,7 +134,7 @@ public final class RemoveMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/remove/issue-30/one-line-comment.ftl"), tmp);
 
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "src/test/resources/remove/header.txt";
         remove.project = new MavenProjectStub();
         remove.execute();
@@ -154,14 +154,14 @@ public final class RemoveMojoTest {
 
         // Let's apply the licene
         LicenseFormatMojo format = new LicenseFormatMojo();
-        format.baseBasedir = tmp;
+        format.defaultBasedir = tmp;
         format.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
         format.project = new MavenProjectStub();
         format.execute();
         
         // Let's try to remove it
         LicenseRemoveMojo remove = new LicenseRemoveMojo();
-        remove.baseBasedir = tmp;
+        remove.defaultBasedir = tmp;
         remove.legacyConfigHeader = "com/mycila/maven/plugin/license/templates/GPL-3.txt";
         remove.project = new MavenProjectStub();
 //        remove.keywords = new String[]{"GNU"};

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
@@ -40,7 +40,7 @@ public final class StrictTest {
 
         // all the headers are by default checked not strictlty
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/issue76");
+        check.defaultBasedir = new File("src/test/resources/check/issue76");
         check.legacyConfigHeader = "src/test/resources/test-header1.txt";
         check.project = project;
         check.strictCheck = false;
@@ -69,7 +69,7 @@ public final class StrictTest {
 
         // all the headers are by default checked not strictlty
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/strict");
+        check.defaultBasedir = new File("src/test/resources/check/strict");
         check.legacyConfigHeader = "src/test/resources/test-header1-diff.txt";
         check.project = project;
         check.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/StrictTest.java
@@ -40,8 +40,8 @@ public final class StrictTest {
 
         // all the headers are by default checked not strictlty
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/issue76");
-        check.header = "src/test/resources/test-header1.txt";
+        check.baseBasedir = new File("src/test/resources/check/issue76");
+        check.legacyConfigHeader = "src/test/resources/test-header1.txt";
         check.project = project;
         check.strictCheck = false;
         check.execute();
@@ -69,8 +69,8 @@ public final class StrictTest {
 
         // all the headers are by default checked not strictlty
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/strict");
-        check.header = "src/test/resources/test-header1-diff.txt";
+        check.baseBasedir = new File("src/test/resources/check/strict");
+        check.legacyConfigHeader = "src/test/resources/test-header1-diff.txt";
         check.project = project;
         check.execute();
 

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
@@ -45,10 +45,10 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/doc2.txt"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/header.txt";
         updater.project = new MavenProjectStub();
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.execute();
 
         assertEquals(FileUtils.read(new File(tmp, "doc1.txt"), System.getProperty("file.encoding")), "====\r\n    My @Copyright license 2 with my-custom-value and 2008 and doc1.txt\r\n====\r\n\r\nsome data\r\n");
@@ -63,10 +63,10 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/doc2.txt"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/update/header.txt"), "utf-8");
         updater.project = new MavenProjectStub();
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.execute();
 
         assertEquals(FileUtils.read(new File(tmp, "doc1.txt"), System.getProperty("file.encoding")), "====\r\n    My @Copyright license 2 with my-custom-value and 2008 and doc1.txt\r\n====\r\n\r\nsome data\r\n");
@@ -82,10 +82,10 @@ public final class UpdateMojoTest {
 
         // only update those files without a copyright header
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/header.txt";
         updater.project = new MavenProjectStub();
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.skipExistingHeaders = true;
         updater.execute();
 
@@ -94,10 +94,10 @@ public final class UpdateMojoTest {
 
         // expect unchanged header to fail check against new header
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = tmp;
+        check.defaultBasedir = tmp;
         check.legacyConfigHeader = "src/test/resources/update/header.txt";
         check.project = new MavenProjectStub();
-        check.baseProperties = ImmutableMap.of("year", "2008");
+        check.defaultProperties = ImmutableMap.of("year", "2008");
         check.skipExistingHeaders = false;
 
         try {
@@ -122,9 +122,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue50/test3.properties"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/header.txt";
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("properties", "SCRIPT_STYLE");
         }};
@@ -147,9 +147,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue48/test2.php"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/header.txt";
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("properties", "SCRIPT_STYLE");
         }};
@@ -186,9 +186,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue44/test.asp"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/header.txt";
-        updater.baseProperties = ImmutableMap.of("year", "2008");
+        updater.defaultProperties = ImmutableMap.of("year", "2008");
         updater.project = new MavenProjectStub();
         updater.execute();
 
@@ -213,7 +213,7 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue14/test.properties"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/update/issue14/header.txt";
         updater.project = new MavenProjectStub();
         updater.execute();
@@ -252,13 +252,13 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/issues/issue-71/issue-71.txt.extended"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.baseBasedir = tmp;
+        updater.defaultBasedir = tmp;
         updater.legacyConfigHeader = "src/test/resources/issues/issue-71/issue-71-header.txt";
         updater.project = new MavenProjectStub();
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("txt.extended", "EXTENDED_STYLE");
         }};
-        updater.baseHeaderDefinitions = new String[]{"/issues/issue-71/issue-71-additionalHeaderDefinitions.xml"};
+        updater.defaultHeaderDefinitions = new String[]{"/issues/issue-71/issue-71-additionalHeaderDefinitions.xml"};
         updater.execute();
 
 
@@ -275,7 +275,7 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue37/xwiki.xml"), tmp);
         
         LicenseFormatMojo execution1 = new LicenseFormatMojo();
-        execution1.baseBasedir = tmp;
+        execution1.defaultBasedir = tmp;
         execution1.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
         execution1.project = new MavenProjectStub();
         execution1.execute();
@@ -283,7 +283,7 @@ public final class UpdateMojoTest {
         String execution1FileContent = FileUtils.read(new File(tmp, "xwiki.xml"), System.getProperty("file.encoding"));
         
         LicenseFormatMojo execution2 = new LicenseFormatMojo();
-        execution2.baseBasedir = tmp;
+        execution2.defaultBasedir = tmp;
         execution2.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
         execution2.project = new MavenProjectStub();
         execution2.execute();
@@ -300,7 +300,7 @@ public final class UpdateMojoTest {
             FileUtils.copyFileToFolder(new File("src/test/resources/update/issue30/one-line-comment.ftl"), tmp);
     
             LicenseFormatMojo updater = new LicenseFormatMojo();
-            updater.baseBasedir = tmp;
+            updater.defaultBasedir = tmp;
             updater.legacyConfigHeader = "src/test/resources/single-line-header.txt";
             updater.project = new MavenProjectStub();
             updater.execute();

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UpdateMojoTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.nio.charset.Charset;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -46,10 +45,10 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/doc2.txt"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/header.txt";
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/header.txt";
         updater.project = new MavenProjectStub();
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.execute();
 
         assertEquals(FileUtils.read(new File(tmp, "doc1.txt"), System.getProperty("file.encoding")), "====\r\n    My @Copyright license 2 with my-custom-value and 2008 and doc1.txt\r\n====\r\n\r\nsome data\r\n");
@@ -64,10 +63,10 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/doc2.txt"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.inlineHeader = FileUtils.read(new File("src/test/resources/update/header.txt"), "utf-8");
+        updater.baseBasedir = tmp;
+        updater.legacyConfigInlineHeader = FileUtils.read(new File("src/test/resources/update/header.txt"), "utf-8");
         updater.project = new MavenProjectStub();
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.execute();
 
         assertEquals(FileUtils.read(new File(tmp, "doc1.txt"), System.getProperty("file.encoding")), "====\r\n    My @Copyright license 2 with my-custom-value and 2008 and doc1.txt\r\n====\r\n\r\nsome data\r\n");
@@ -83,10 +82,10 @@ public final class UpdateMojoTest {
 
         // only update those files without a copyright header
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/header.txt";
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/header.txt";
         updater.project = new MavenProjectStub();
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.skipExistingHeaders = true;
         updater.execute();
 
@@ -95,10 +94,10 @@ public final class UpdateMojoTest {
 
         // expect unchanged header to fail check against new header
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = tmp;
-        check.header = "src/test/resources/update/header.txt";
+        check.baseBasedir = tmp;
+        check.legacyConfigHeader = "src/test/resources/update/header.txt";
         check.project = new MavenProjectStub();
-        check.properties = ImmutableMap.of("year", "2008");
+        check.baseProperties = ImmutableMap.of("year", "2008");
         check.skipExistingHeaders = false;
 
         try {
@@ -123,9 +122,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue50/test3.properties"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/header.txt";
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("properties", "SCRIPT_STYLE");
         }};
@@ -148,9 +147,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue48/test2.php"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/header.txt";
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("properties", "SCRIPT_STYLE");
         }};
@@ -187,9 +186,9 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue44/test.asp"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/header.txt";
-        updater.properties = ImmutableMap.of("year", "2008");
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/header.txt";
+        updater.baseProperties = ImmutableMap.of("year", "2008");
         updater.project = new MavenProjectStub();
         updater.execute();
 
@@ -214,8 +213,8 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue14/test.properties"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/update/issue14/header.txt";
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/update/issue14/header.txt";
         updater.project = new MavenProjectStub();
         updater.execute();
         final String expectedString = "#" + LS + "" +
@@ -253,13 +252,13 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/issues/issue-71/issue-71.txt.extended"), tmp);
 
         LicenseFormatMojo updater = new LicenseFormatMojo();
-        updater.basedir = tmp;
-        updater.header = "src/test/resources/issues/issue-71/issue-71-header.txt";
+        updater.baseBasedir = tmp;
+        updater.legacyConfigHeader = "src/test/resources/issues/issue-71/issue-71-header.txt";
         updater.project = new MavenProjectStub();
         updater.mapping = new LinkedHashMap<String, String>() {{
             put("txt.extended", "EXTENDED_STYLE");
         }};
-        updater.headerDefinitions = new String[]{"/issues/issue-71/issue-71-additionalHeaderDefinitions.xml"};
+        updater.baseHeaderDefinitions = new String[]{"/issues/issue-71/issue-71-additionalHeaderDefinitions.xml"};
         updater.execute();
 
 
@@ -276,16 +275,16 @@ public final class UpdateMojoTest {
         FileUtils.copyFileToFolder(new File("src/test/resources/update/issue37/xwiki.xml"), tmp);
         
         LicenseFormatMojo execution1 = new LicenseFormatMojo();
-        execution1.basedir = tmp;
-        execution1.header = "src/test/resources/update/issue37/xwiki-license.txt";
+        execution1.baseBasedir = tmp;
+        execution1.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
         execution1.project = new MavenProjectStub();
         execution1.execute();
         
         String execution1FileContent = FileUtils.read(new File(tmp, "xwiki.xml"), System.getProperty("file.encoding"));
         
         LicenseFormatMojo execution2 = new LicenseFormatMojo();
-        execution2.basedir = tmp;
-        execution2.header = "src/test/resources/update/issue37/xwiki-license.txt";
+        execution2.baseBasedir = tmp;
+        execution2.legacyConfigHeader = "src/test/resources/update/issue37/xwiki-license.txt";
         execution2.project = new MavenProjectStub();
         execution2.execute();
         
@@ -301,8 +300,8 @@ public final class UpdateMojoTest {
             FileUtils.copyFileToFolder(new File("src/test/resources/update/issue30/one-line-comment.ftl"), tmp);
     
             LicenseFormatMojo updater = new LicenseFormatMojo();
-            updater.basedir = tmp;
-            updater.header = "src/test/resources/single-line-header.txt";
+            updater.baseBasedir = tmp;
+            updater.legacyConfigHeader = "src/test/resources/single-line-header.txt";
             updater.project = new MavenProjectStub();
             updater.execute();
             

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
@@ -30,11 +30,11 @@ public final class UseDefaultExcludesMojoTest {
     public void test_include_and_fail() throws Exception {
         try {
             LicenseCheckMojo check = new LicenseCheckMojo();
-            check.baseBasedir = new File("src/test/resources/check");
+            check.defaultBasedir = new File("src/test/resources/check");
             check.legacyConfigHeader = "header.txt";
             check.project = new MavenProjectStub();
             check.legacyConfigExcludes = new String[]{"doc1.txt"};
-            check.baseUseDefaultExcludes = false;
+            check.defaultUseDefaultExcludes = false;
             check.strictCheck = true;
             check.execute();
         } catch (Exception e) {
@@ -45,10 +45,10 @@ public final class UseDefaultExcludesMojoTest {
     @Test
     public void check_defaultExcludes_exclude_Netbeans_Configuration() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/excludes/issue-68");
+        check.defaultBasedir = new File("src/test/resources/excludes/issue-68");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.baseUseDefaultExcludes = true;
+        check.defaultUseDefaultExcludes = true;
         check.strictCheck = true;
         check.execute();
     }
@@ -57,10 +57,10 @@ public final class UseDefaultExcludesMojoTest {
     public void check_withoutDefaultExcludes_Netbeans_Configuration_Is_Reported() {
         try {
             LicenseCheckMojo check = new LicenseCheckMojo();
-            check.baseBasedir = new File("src/test/resources/excludes/issue-68");
+            check.defaultBasedir = new File("src/test/resources/excludes/issue-68");
             check.legacyConfigHeader = "header.txt";
             check.project = new MavenProjectStub();
-            check.baseUseDefaultExcludes = false;
+            check.defaultUseDefaultExcludes = false;
             check.strictCheck = true;
             check.execute();
         } catch (Exception e) {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultExcludesMojoTest.java
@@ -30,11 +30,11 @@ public final class UseDefaultExcludesMojoTest {
     public void test_include_and_fail() throws Exception {
         try {
             LicenseCheckMojo check = new LicenseCheckMojo();
-            check.basedir = new File("src/test/resources/check");
-            check.header = "header.txt";
+            check.baseBasedir = new File("src/test/resources/check");
+            check.legacyConfigHeader = "header.txt";
             check.project = new MavenProjectStub();
-            check.excludes = new String[]{"doc1.txt"};
-            check.useDefaultExcludes = false;
+            check.legacyConfigExcludes = new String[]{"doc1.txt"};
+            check.baseUseDefaultExcludes = false;
             check.strictCheck = true;
             check.execute();
         } catch (Exception e) {
@@ -45,10 +45,10 @@ public final class UseDefaultExcludesMojoTest {
     @Test
     public void check_defaultExcludes_exclude_Netbeans_Configuration() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/excludes/issue-68");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/excludes/issue-68");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
-        check.useDefaultExcludes = true;
+        check.baseUseDefaultExcludes = true;
         check.strictCheck = true;
         check.execute();
     }
@@ -57,10 +57,10 @@ public final class UseDefaultExcludesMojoTest {
     public void check_withoutDefaultExcludes_Netbeans_Configuration_Is_Reported() {
         try {
             LicenseCheckMojo check = new LicenseCheckMojo();
-            check.basedir = new File("src/test/resources/excludes/issue-68");
-            check.header = "header.txt";
+            check.baseBasedir = new File("src/test/resources/excludes/issue-68");
+            check.legacyConfigHeader = "header.txt";
             check.project = new MavenProjectStub();
-            check.useDefaultExcludes = false;
+            check.baseUseDefaultExcludes = false;
             check.strictCheck = true;
             check.execute();
         } catch (Exception e) {

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
@@ -34,7 +34,7 @@ public final class UseDefaultMappingMojoTest {
     @Test
     public void test_not_useDefaultMapping() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = false;
@@ -49,7 +49,7 @@ public final class UseDefaultMappingMojoTest {
     @Test
     public void test_useDefaultMapping() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check");
+        check.defaultBasedir = new File("src/test/resources/check");
         check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/UseDefaultMappingMojoTest.java
@@ -34,8 +34,8 @@ public final class UseDefaultMappingMojoTest {
     @Test
     public void test_not_useDefaultMapping() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = false;
         check.strictCheck = true;
@@ -49,8 +49,8 @@ public final class UseDefaultMappingMojoTest {
     @Test
     public void test_useDefaultMapping() throws Exception {
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check");
-        check.header = "header.txt";
+        check.baseBasedir = new File("src/test/resources/check");
+        check.legacyConfigHeader = "header.txt";
         check.project = new MavenProjectStub();
         check.useDefaultMapping = true;
         check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
@@ -37,7 +37,7 @@ public final class ValidHeaderMojoTest {
         format.execute();*/
 
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.baseBasedir = new File("src/test/resources/check/valid");
+        check.defaultBasedir = new File("src/test/resources/check/valid");
         check.legacyConfigHeader = "src/test/resources/test-header1.txt";
         check.project = new MavenProjectStub();
         check.strictCheck = true;

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/ValidHeaderMojoTest.java
@@ -37,8 +37,8 @@ public final class ValidHeaderMojoTest {
         format.execute();*/
 
         LicenseCheckMojo check = new LicenseCheckMojo();
-        check.basedir = new File("src/test/resources/check/valid");
-        check.header = "src/test/resources/test-header1.txt";
+        check.baseBasedir = new File("src/test/resources/check/valid");
+        check.legacyConfigHeader = "src/test/resources/test-header1.txt";
         check.project = new MavenProjectStub();
         check.strictCheck = true;
         try {
@@ -48,7 +48,7 @@ public final class ValidHeaderMojoTest {
             assertEquals("Some files do not have the expected license header", e.getMessage());
         }
 
-        check.validHeaders = new String[]{"src/test/resources/check/header2.txt"};
+        check.legacyConfigValidHeaders = new String[]{"src/test/resources/check/header2.txt"};
         check.execute();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
     <properties>
         <jdk.version>1.6</jdk.version>
         <mycila.github.name>license-maven-plugin</mycila.github.name>
+        <junit.version>4.12</junit.version>
     </properties>
 
     <modules>
@@ -108,13 +109,22 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>${junit.version}</version>
             </dependency>
 
         </dependencies>
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
This PR adds a new feature via config `<licenseSets>`.

You can now specify multiple `<licenseSet>` each with a different license, basedir, include and excludes paths, etc.

This means that a single execution of the plugin can check different files against different licenses. This is very useful in projects where you have a mix of source code licenses... perhaps because some files have been copied in from other compatible open source projects.

The changes are backwards compatible, so that the old config style also still works too.