### PR TITLE
ensure exclusions win over inclusions for scanning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 dist: trusty
-
+sudo: false
 language: java
 
-script: mvn clean install --quiet -B
+before_cache:
+  - find $HOME/.m2/repository/ -name *SNAPSHOT | xargs rm -Rf
+
+cache:
+  timeout: 1000
+  directories:
+    - "$HOME/.m2"
+
+script: mvn clean install --quiet -B -Dmaven.artifact.threads=64 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 install: /bin/true
 

--- a/license-maven-plugin/pom.xml
+++ b/license-maven-plugin/pom.xml
@@ -122,7 +122,12 @@
         <dependency> 
             <groupId>org.apache.maven</groupId> 
             <artifactId>maven-settings-builder</artifactId> 
-        </dependency> 
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.shared</groupId>
+            <artifactId>maven-shared-utils</artifactId>
+            <version>3.2.1</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/AbstractLicenseMojo.java
@@ -601,7 +601,9 @@ public abstract class AbstractLicenseMojo extends AbstractMojo {
 
     private String[] listSelectedFiles(final LicenseSet licenseSet) {
         final boolean useDefaultExcludes = (licenseSet.useDefaultExcludes != null ? licenseSet.useDefaultExcludes : defaultUseDefaultExcludes);
-        final Selection selection = new Selection(firstNonNull(licenseSet.basedir, defaultBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes);
+        final Selection selection = new Selection(
+                firstNonNull(licenseSet.basedir, defaultBasedir), licenseSet.includes, buildExcludes(licenseSet), useDefaultExcludes,
+                getLog());
         debug("From: %s", firstNonNull(licenseSet.basedir, defaultBasedir));
         debug("Including: %s", deepToString(selection.getIncluded()));
         debug("Excluding: %s", deepToString(selection.getExcluded()));

--- a/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
+++ b/license-maven-plugin/src/test/java/com/mycila/maven/plugin/license/util/SelectionTest.java
@@ -16,21 +16,35 @@
 package com.mycila.maven.plugin.license.util;
 
 import com.mycila.maven.plugin.license.Default;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.apache.maven.shared.utils.io.DirectoryScanner;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Mathieu Carbou (mathieu.carbou@gmail.com)
  */
 public final class SelectionTest {
+    private final Log log = new SystemStreamLog();
+
     @Test
     public void test_default_select_all() {
-        Selection selection = new Selection(new File("."), new String[0], new String[0], false);
+        Selection selection = new Selection(new File("."), new String[0], new String[0], false, log);
         assertEquals(selection.getExcluded().length, 0);
         assertEquals(selection.getIncluded().length, 1);
         assertTrue(selection.getSelectedFiles().length > 0);
@@ -38,7 +52,7 @@ public final class SelectionTest {
 
     @Test
     public void test_limit_inclusion() {
-        Selection selection = new Selection(new File("."), new String[]{"toto"}, new String[]{"tata"}, false);
+        Selection selection = new Selection(new File("."), new String[]{"toto"}, new String[]{"tata"}, false, log);
         assertEquals(selection.getExcluded().length, 1);
         assertEquals(selection.getIncluded().length, 1);
         assertEquals(selection.getSelectedFiles().length, 0);
@@ -46,10 +60,83 @@ public final class SelectionTest {
 
     @Test
     public void test_limit_inclusion_and_check_default_excludes() {
-        Selection selection = new Selection(new File("."), new String[]{"toto"}, new String[0], true);
+        Selection selection = new Selection(new File("."), new String[]{"toto"}, new String[0], true, log);
         assertEquals(selection.getExcluded().length, Default.EXCLUDES.length); // default exludes from Scanner and Selection + toto
         assertEquals(selection.getIncluded().length, 1);
         assertEquals(selection.getSelectedFiles().length, 0);
         assertTrue(Arrays.asList(selection.getExcluded()).containsAll(Arrays.asList(Default.EXCLUDES)));
+    }
+
+    @Test
+    public void test_exclusions_respect_with_fastScan() throws IOException {
+        SystemStreamLog log = new SystemStreamLog() {
+            @Override
+            public boolean isDebugEnabled() {
+                return true;
+            }
+        };
+        File root = createAFakeProject(log);
+        Selection selection = new Selection(root,
+                new String[] { "**" + File.separator + "*.txt" },
+                new String[] {"target" + File.separator + "**", "module/**/target" + File.separator + "**"}, false,
+                log);
+
+        selection.getSelectedFiles(); // triggers scan and scanner build
+        String debugMessage = buildDebugMessage(selection.getScanner());
+        assertIncludedFilesInFakeProject(selection, debugMessage);
+        assertEquals(debugMessage, 0, selection.getScanner().getExcludedFiles().length);
+    }
+
+    private String buildDebugMessage(DirectoryScanner scanner) {
+        return "excludedDirs=" + asList(scanner.getExcludedDirectories()) + ",\n" +
+                "excludedFiles=" + asList(scanner.getExcludedFiles()) + ",\n" +
+                "includedDirsFiles=" + asList(scanner.getIncludedDirectories()) + ",\n" +
+                "includedFiles=" + asList(scanner.getIncludedFiles()) + ",\n" +
+                "notIncludedDirs=" + asList(scanner.getNotIncludedDirectories()) + ",\n" +
+                "notIncludedFiles=" + asList(scanner.getNotIncludedFiles()) + ",\n" +
+                "diskFiles=" + listFiles(scanner.getBasedir(), new ArrayList<File>());
+    }
+
+    private Collection<File> listFiles(File basedir, Collection<File> files) {
+        files.add(basedir);
+        for (File f : basedir.listFiles()) {
+            if (f.isDirectory()) {
+                listFiles(f, files);
+            } else {
+                files.add(f);
+            }
+        }
+        return files;
+    }
+
+    private void assertIncludedFilesInFakeProject(Selection selection, String debugMessage) {
+        List<String> selected = new ArrayList<String>(asList(selection.getSelectedFiles()));
+        Collections.sort(selected);
+        assertEquals(debugMessage, asList("included.txt", "module/src/main/java/not-ignored.txt", "module/sub/subsub/src/main/java/not-ignored.txt"), selected);
+    }
+
+    private File createAFakeProject(Log log) throws IOException {
+        File temp = new File("target/workdir_" + UUID.randomUUID().toString());
+        touch(new File(temp, "included.txt"), log);
+        touch(new File(temp, "target/ignored.txt"), log);
+        touch(new File(temp, "module/src/main/java/not-ignored.txt"), log);
+        touch(new File(temp, "module/target/ignored.txt"), log);
+        touch(new File(temp, "module/sub/subsub/src/main/java/not-ignored.txt"), log);
+        touch(new File(temp, "module/sub/subsub/target/foo/not-ignored.txt"), log);
+        return temp;
+    }
+
+    private void touch(File newFile, Log log) throws IOException {
+        final File parentFile = newFile.getParentFile();
+        if (parentFile != null && !parentFile.isDirectory() && !parentFile.mkdirs()) {
+            fail("Can't create '" + parentFile + "'");
+        }
+        final FileWriter w = new FileWriter(newFile);
+        w.write("touched");
+        w.close();
+        if (!newFile.exists()) {
+            fail("Can't create " + newFile);
+        }
+        log.debug("Created '" + newFile.getAbsolutePath() + "'");
     }
 }


### PR DESCRIPTION
If any inclusion is "**anything" then DirectoryScanner will browse excluded folders. It completely defeats most of exclusions and typically let the plugin go through target and node_modules which can be very time consuming.
With this patch, my license check (only) went from 25s to 2.5s.