### PR TITLE
minor: default error message should contain the quick fix that works in ~99% cases

### DIFF
--- a/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
+++ b/license-maven-plugin/src/main/java/com/mycila/maven/plugin/license/LicenseCheckMojo.java
@@ -35,8 +35,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 @Mojo(name = "check", defaultPhase = LifecyclePhase.VERIFY, threadSafe = true)
 public final class LicenseCheckMojo extends AbstractLicenseMojo {
 
-    @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header")
-    public String errorMessage = "Some files do not have the expected license header";
+    @Parameter(property = "license.errorMessage", defaultValue = "Some files do not have the expected license header, try mvn license:format")
+    public String errorMessage = "Some files do not have the expected license header, try mvn license:format";
 
     public final Collection<File> missingHeaders = new ConcurrentLinkedQueue<File>();
 


### PR DESCRIPTION
Suggest the command that can fix the issue, so that users unfamiliar with the plugin can do the quick fix.