### PR TITLE
[pom] Make project look into .m2/cache for mycila-pom as not part of this project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <groupId>com.mycila</groupId>
         <artifactId>mycila-pom</artifactId>
         <version>3</version>
+        <relativePath />
     </parent>
 
     <artifactId>license-maven-plugin-parent</artifactId>


### PR DESCRIPTION
When the parent is not physicaly part of a project, its imporant to force project to look to .m2 cache.  Otherwise it will throw warnings if there is a pom up one directory that is not for this project.